### PR TITLE
Reject unused keys in additional_metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Changes
+
+* Unused keys in `additional_metadata` when writing a role will now cause an error [[GH-5](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/pull/5)]
+
 ## 0.1.0 (May 20th, 2022)
 
 Initial implementation [[GH-2](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/pull/2)][[GH-3](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/pull/3)][[GH-4](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/pull/4)]

--- a/path_roles.go
+++ b/path_roles.go
@@ -214,7 +214,14 @@ func (b *backend) pathRolesWrite(ctx context.Context, req *logical.Request, d *f
 		entry.NameTemplate = nameTemplate.(string)
 	}
 	if metadata, ok := d.GetOk("additional_metadata"); ok {
-		if err := mapstructure.Decode(metadata, &entry.Metadata); err != nil {
+		dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+			ErrorUnused: true,
+			Result:      &entry.Metadata,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create decoder for additional metadata: %w", err)
+		}
+		if err := dec.Decode(metadata); err != nil {
 			return logical.ErrorResponse("additional_metadata should be a nested map, with only 'labels' and 'annotations' as the top level keys"), nil
 		}
 	}


### PR DESCRIPTION
This uses `ErrorUnused` from `mapstructure` to ensure that when users give data in the wrong format, they get a helpful error message. I tripped up on this while writing the API docs.