### PR TITLE
Split additional annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Changes
+
+* Split `additional_metadata` into `extra_annotations` and `extra_labels` parameters [[GH-7](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/pull/7)]
+
 ## 0.1.0 (May 20th, 2022)
 
 Initial implementation [[GH-2](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/pull/2)][[GH-3](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/pull/3)][[GH-4](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/pull/4)]

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,16 @@ KIND_CLUSTER_NAME?=vault-plugin-secrets-kubernetes
 # kind k8s version
 KIND_K8S_VERSION?=v1.23.6
 
+PKG=github.com/hashicorp/vault-plugin-secrets-kubernetes
+LDFLAGS?="-X '$(PKG).WALRollbackMinAge=10s'"
+
 .PHONY: default
 default: dev
 
+# dev target sets WALRollbackMinAge to 10s instead of the default 10 minutes to speed up integration tests
 .PHONY: dev
 dev:
-	CGO_ENABLED=0 go build -o bin/vault-plugin-secrets-kubernetes cmd/vault-plugin-secrets-kubernetes/main.go
+	CGO_ENABLED=0 go build -ldflags $(LDFLAGS) -o bin/vault-plugin-secrets-kubernetes cmd/vault-plugin-secrets-kubernetes/main.go
 
 .PHONY: test
 test: fmtcheck

--- a/client.go
+++ b/client.go
@@ -63,13 +63,13 @@ func (c *client) createToken(ctx context.Context, namespace, name string, ttl ti
 
 func (c *client) createServiceAccount(ctx context.Context, namespace, name string, vaultRole *roleEntry, ownerRef metav1.OwnerReference) (*v1.ServiceAccount, error) {
 	// Set standardLabels last so that users can't override them
-	labels := combineMaps(vaultRole.Metadata.Labels, standardLabels)
+	labels := combineMaps(vaultRole.ExtraLabels, standardLabels)
 	serviceAccountConfig := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
 			Namespace:       namespace,
 			Labels:          labels,
-			Annotations:     vaultRole.Metadata.Annotations,
+			Annotations:     vaultRole.ExtraAnnotations,
 			OwnerReferences: []metav1.OwnerReference{ownerRef},
 		},
 	}
@@ -94,11 +94,11 @@ func (c *client) createRole(ctx context.Context, namespace, name string, vaultRo
 		return thisOwnerRef, err
 	}
 	// Set standardLabels last so that users can't override them
-	labels := combineMaps(vaultRole.Metadata.Labels, standardLabels)
+	labels := combineMaps(vaultRole.ExtraLabels, standardLabels)
 	objectMeta := metav1.ObjectMeta{
 		Name:        name,
 		Labels:      labels,
-		Annotations: vaultRole.Metadata.Annotations,
+		Annotations: vaultRole.ExtraAnnotations,
 	}
 
 	switch vaultRole.K8sRoleType {
@@ -154,11 +154,11 @@ func (c *client) createRoleBinding(ctx context.Context, namespace, name, k8sRole
 		Name:       name,
 	}
 	// Set standardLabels last so that users can't override them
-	labels := combineMaps(vaultRole.Metadata.Labels, standardLabels)
+	labels := combineMaps(vaultRole.ExtraLabels, standardLabels)
 	objectMeta := metav1.ObjectMeta{
 		Name:        name,
 		Labels:      labels,
-		Annotations: vaultRole.Metadata.Annotations,
+		Annotations: vaultRole.ExtraAnnotations,
 	}
 	if ownerRef != nil {
 		objectMeta.OwnerReferences = []metav1.OwnerReference{*ownerRef}

--- a/integrationtest/creds_integration_test.go
+++ b/integrationtest/creds_integration_test.go
@@ -145,8 +145,9 @@ func TestCreds_service_account_name(t *testing.T) {
 	roleResponse, err := client.Logical().Read(path + "/roles/testrole")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{
-		"additional_metadata":           map[string]interface{}{},
 		"allowed_kubernetes_namespaces": []interface{}{"*"},
+		"extra_labels":                  nil,
+		"extra_annotations":             nil,
 		"generated_role_rules":          "",
 		"kubernetes_role_name":          "",
 		"kubernetes_role_type":          "Role",
@@ -201,17 +202,16 @@ func TestCreds_kubernetes_role_name(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Role type", func(t *testing.T) {
-		metadata := map[string]interface{}{
-			"labels": map[string]interface{}{
-				"environment": "testing",
-			},
-			"annotations": map[string]interface{}{
-				"tested": "today",
-			},
+		extraLabels := map[string]string{
+			"environment": "testing",
+		}
+		extraAnnotations := map[string]string{
+			"tested": "today",
 		}
 		roleConfig := map[string]interface{}{
-			"additional_metadata":           metadata,
 			"allowed_kubernetes_namespaces": []string{"test"},
+			"extra_annotations":             extraAnnotations,
+			"extra_labels":                  extraLabels,
 			"kubernetes_role_name":          "test-role-list-pods",
 			"kubernetes_role_type":          "role",
 			"token_default_ttl":             "1h",
@@ -219,8 +219,9 @@ func TestCreds_kubernetes_role_name(t *testing.T) {
 			"name_template":                 `{{ printf "v-custom-name-%s" (random 24) | truncate 62 | lowercase }}`,
 		}
 		expectedRoleResponse := map[string]interface{}{
-			"additional_metadata":           metadata,
 			"allowed_kubernetes_namespaces": []interface{}{"test"},
+			"extra_annotations":             asMapInterface(extraAnnotations),
+			"extra_labels":                  asMapInterface(extraLabels),
 			"generated_role_rules":          "",
 			"kubernetes_role_name":          "test-role-list-pods",
 			"kubernetes_role_type":          "Role",
@@ -234,25 +235,25 @@ func TestCreds_kubernetes_role_name(t *testing.T) {
 	})
 
 	t.Run("ClusterRole type", func(t *testing.T) {
-		metadata := map[string]interface{}{
-			"labels": map[string]interface{}{
-				"environment": "staging",
-			},
-			"annotations": map[string]interface{}{
-				"tested": "tomorrow",
-			},
+		extraLabels := map[string]string{
+			"environment": "staging",
+		}
+		extraAnnotations := map[string]string{
+			"tested": "tomorrow",
 		}
 		roleConfig := map[string]interface{}{
-			"additional_metadata":           metadata,
 			"allowed_kubernetes_namespaces": []string{"test"},
+			"extra_annotations":             extraAnnotations,
+			"extra_labels":                  extraLabels,
 			"kubernetes_role_name":          "test-cluster-role-list-pods",
 			"kubernetes_role_type":          "Clusterrole",
 			"token_default_ttl":             "1h",
 			"token_max_ttl":                 "24h",
 		}
 		expectedRoleResponse := map[string]interface{}{
-			"additional_metadata":           metadata,
 			"allowed_kubernetes_namespaces": []interface{}{"test"},
+			"extra_annotations":             asMapInterface(extraAnnotations),
+			"extra_labels":                  asMapInterface(extraLabels),
 			"generated_role_rules":          "",
 			"kubernetes_role_name":          "test-cluster-role-list-pods",
 			"kubernetes_role_type":          "ClusterRole",
@@ -300,25 +301,25 @@ func TestCreds_generated_role_rules(t *testing.T) {
 ]`
 
 	t.Run("Role type", func(t *testing.T) {
-		metadata := map[string]interface{}{
-			"labels": map[string]interface{}{
-				"environment": "testing",
-			},
-			"annotations": map[string]interface{}{
-				"tested": "today",
-			},
+		extraLabels := map[string]string{
+			"environment": "testing",
+		}
+		extraAnnotations := map[string]string{
+			"tested": "today",
 		}
 		roleConfig := map[string]interface{}{
-			"additional_metadata":           metadata,
 			"allowed_kubernetes_namespaces": []string{"test"},
+			"extra_annotations":             extraAnnotations,
+			"extra_labels":                  extraLabels,
 			"generated_role_rules":          roleRulesYAML,
 			"kubernetes_role_type":          "RolE",
 			"token_default_ttl":             "1h",
 			"token_max_ttl":                 "24h",
 		}
 		expectedRoleResponse := map[string]interface{}{
-			"additional_metadata":           metadata,
 			"allowed_kubernetes_namespaces": []interface{}{"test"},
+			"extra_annotations":             asMapInterface(extraAnnotations),
+			"extra_labels":                  asMapInterface(extraLabels),
 			"generated_role_rules":          roleRulesYAML,
 			"kubernetes_role_name":          "",
 			"kubernetes_role_type":          "Role",
@@ -332,27 +333,27 @@ func TestCreds_generated_role_rules(t *testing.T) {
 	})
 
 	t.Run("ClusterRole type", func(t *testing.T) {
-		metadata := map[string]interface{}{
-			"labels": map[string]interface{}{
-				"environment": "staging",
-				"asdf":        "123",
-			},
-			"annotations": map[string]interface{}{
-				"tested":  "tomorrow",
-				"checked": "again",
-			},
+		extraLabels := map[string]string{
+			"environment": "staging",
+			"asdf":        "123",
+		}
+		extraAnnotations := map[string]string{
+			"tested":  "tomorrow",
+			"checked": "again",
 		}
 		roleConfig := map[string]interface{}{
-			"additional_metadata":           metadata,
 			"allowed_kubernetes_namespaces": []string{"test"},
+			"extra_annotations":             extraAnnotations,
+			"extra_labels":                  extraLabels,
 			"generated_role_rules":          roleRulesJSON,
 			"kubernetes_role_type":          "clusterRole",
 			"token_default_ttl":             "1h",
 			"token_max_ttl":                 "24h",
 		}
 		expectedRoleResponse := map[string]interface{}{
-			"additional_metadata":           metadata,
 			"allowed_kubernetes_namespaces": []interface{}{"test"},
+			"extra_annotations":             asMapInterface(extraAnnotations),
+			"extra_labels":                  asMapInterface(extraLabels),
 			"generated_role_rules":          roleRulesJSON,
 			"kubernetes_role_name":          "",
 			"kubernetes_role_type":          "ClusterRole",

--- a/integrationtest/helpers.go
+++ b/integrationtest/helpers.go
@@ -118,7 +118,7 @@ func verifyRole(t *testing.T, roleConfig map[string]interface{}, credsResponse *
 	roleType := strings.ToLower(roleConfig["kubernetes_role_type"].(string))
 
 	expectedLabels := makeExpectedLabels(t, roleConfig["extra_labels"].(map[string]interface{}))
-	expectedAnnotations := makeExpectedAnnotations(roleConfig["extra_annotations"].(map[string]interface{}))
+	expectedAnnotations := asMapString(roleConfig["extra_annotations"].(map[string]interface{}))
 	expectedRules := makeRules(t, roleConfig["generated_role_rules"].(string))
 
 	returnedLabels := map[string]string{}
@@ -154,7 +154,7 @@ func verifyBinding(t *testing.T, roleConfig map[string]interface{}, credsRespons
 	objName := credsResponse.Data["service_account_name"].(string)
 
 	expectedLabels := makeExpectedLabels(t, roleConfig["extra_labels"].(map[string]interface{}))
-	expectedAnnotations := makeExpectedAnnotations(roleConfig["extra_annotations"].(map[string]interface{}))
+	expectedAnnotations := asMapString(roleConfig["extra_annotations"].(map[string]interface{}))
 	expectedSubjects := []rbacv1.Subject{
 		{
 			Kind:      "ServiceAccount",
@@ -195,7 +195,7 @@ func verifyServiceAccount(t *testing.T, roleConfig map[string]interface{}, creds
 	objName := credsResponse.Data["service_account_name"].(string)
 
 	expectedLabels := makeExpectedLabels(t, roleConfig["extra_labels"].(map[string]interface{}))
-	expectedAnnotations := makeExpectedAnnotations(roleConfig["extra_annotations"].(map[string]interface{}))
+	expectedAnnotations := asMapString(roleConfig["extra_annotations"].(map[string]interface{}))
 
 	k8sClient := newK8sClient(t, os.Getenv("SUPER_JWT"))
 	acct, err := k8sClient.CoreV1().ServiceAccounts("test").Get(context.Background(), objName, metav1.GetOptions{})
@@ -419,10 +419,6 @@ func makeExpectedLabels(t *testing.T, extraLabels map[string]interface{}) map[st
 		expectedLabels = standardLabels
 	}
 	return expectedLabels
-}
-
-func makeExpectedAnnotations(extraAnnotations map[string]interface{}) map[string]string {
-	return asMapString(extraAnnotations)
 }
 
 func asMapInterface(m map[string]string) map[string]interface{} {

--- a/integrationtest/helpers.go
+++ b/integrationtest/helpers.go
@@ -117,8 +117,8 @@ func verifyRole(t *testing.T, roleConfig map[string]interface{}, credsResponse *
 	roleName := credsResponse.Data["service_account_name"].(string)
 	roleType := strings.ToLower(roleConfig["kubernetes_role_type"].(string))
 
-	expectedLabels := makeExpectedLabels(t, asMapString(roleConfig["extra_labels"].(map[string]interface{})))
-	expectedAnnotations := asMapString(roleConfig["extra_annotations"].(map[string]interface{}))
+	expectedLabels := makeExpectedLabels(t, roleConfig["extra_labels"].(map[string]interface{}))
+	expectedAnnotations := makeExpectedAnnotations(roleConfig["extra_annotations"].(map[string]interface{}))
 	expectedRules := makeRules(t, roleConfig["generated_role_rules"].(string))
 
 	returnedLabels := map[string]string{}
@@ -153,8 +153,8 @@ func verifyBinding(t *testing.T, roleConfig map[string]interface{}, credsRespons
 	// or ClusterRole
 	objName := credsResponse.Data["service_account_name"].(string)
 
-	expectedLabels := makeExpectedLabels(t, asMapString(roleConfig["extra_labels"].(map[string]interface{})))
-	expectedAnnotations := asMapString(roleConfig["extra_annotations"].(map[string]interface{}))
+	expectedLabels := makeExpectedLabels(t, roleConfig["extra_labels"].(map[string]interface{}))
+	expectedAnnotations := makeExpectedAnnotations(roleConfig["extra_annotations"].(map[string]interface{}))
 	expectedSubjects := []rbacv1.Subject{
 		{
 			Kind:      "ServiceAccount",
@@ -194,8 +194,8 @@ func verifyServiceAccount(t *testing.T, roleConfig map[string]interface{}, creds
 	// or ClusterRole
 	objName := credsResponse.Data["service_account_name"].(string)
 
-	expectedLabels := makeExpectedLabels(t, asMapString(roleConfig["extra_labels"].(map[string]interface{})))
-	expectedAnnotations := asMapString(roleConfig["extra_annotations"].(map[string]interface{}))
+	expectedLabels := makeExpectedLabels(t, roleConfig["extra_labels"].(map[string]interface{}))
+	expectedAnnotations := makeExpectedAnnotations(roleConfig["extra_annotations"].(map[string]interface{}))
 
 	k8sClient := newK8sClient(t, os.Getenv("SUPER_JWT"))
 	acct, err := k8sClient.CoreV1().ServiceAccounts("test").Get(context.Background(), objName, metav1.GetOptions{})
@@ -409,16 +409,20 @@ func makeRules(t *testing.T, rules string) []rbacv1.PolicyRule {
 	return policyRules.Rules
 }
 
-func makeExpectedLabels(t *testing.T, userLabels map[string]string) map[string]string {
+func makeExpectedLabels(t *testing.T, extraLabels map[string]interface{}) map[string]string {
 	t.Helper()
 
 	expectedLabels := map[string]string{}
-	if userLabels != nil {
-		expectedLabels = combineMaps(userLabels, standardLabels)
+	if extraLabels != nil {
+		expectedLabels = combineMaps(asMapString(extraLabels), standardLabels)
 	} else {
 		expectedLabels = standardLabels
 	}
 	return expectedLabels
+}
+
+func makeExpectedAnnotations(extraAnnotations map[string]interface{}) map[string]string {
+	return asMapString(extraAnnotations)
 }
 
 func asMapInterface(m map[string]string) map[string]interface{} {

--- a/integrationtest/helpers.go
+++ b/integrationtest/helpers.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/vault/api"
-	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	josejwt "gopkg.in/square/go-jose.v2/jwt"
@@ -118,8 +117,8 @@ func verifyRole(t *testing.T, roleConfig map[string]interface{}, credsResponse *
 	roleName := credsResponse.Data["service_account_name"].(string)
 	roleType := strings.ToLower(roleConfig["kubernetes_role_type"].(string))
 
-	expectedLabels := makeExpectedLabels(t, roleConfig["additional_metadata"].(map[string]interface{}))
-	expectedAnnotations := makeExpectedAnnotations(t, roleConfig["additional_metadata"].(map[string]interface{}))
+	expectedLabels := makeExpectedLabels(t, asMapString(roleConfig["extra_labels"].(map[string]interface{})))
+	expectedAnnotations := asMapString(roleConfig["extra_annotations"].(map[string]interface{}))
 	expectedRules := makeRules(t, roleConfig["generated_role_rules"].(string))
 
 	returnedLabels := map[string]string{}
@@ -154,8 +153,8 @@ func verifyBinding(t *testing.T, roleConfig map[string]interface{}, credsRespons
 	// or ClusterRole
 	objName := credsResponse.Data["service_account_name"].(string)
 
-	expectedLabels := makeExpectedLabels(t, roleConfig["additional_metadata"].(map[string]interface{}))
-	expectedAnnotations := makeExpectedAnnotations(t, roleConfig["additional_metadata"].(map[string]interface{}))
+	expectedLabels := makeExpectedLabels(t, asMapString(roleConfig["extra_labels"].(map[string]interface{})))
+	expectedAnnotations := asMapString(roleConfig["extra_annotations"].(map[string]interface{}))
 	expectedSubjects := []rbacv1.Subject{
 		{
 			Kind:      "ServiceAccount",
@@ -195,8 +194,8 @@ func verifyServiceAccount(t *testing.T, roleConfig map[string]interface{}, creds
 	// or ClusterRole
 	objName := credsResponse.Data["service_account_name"].(string)
 
-	expectedLabels := makeExpectedLabels(t, roleConfig["additional_metadata"].(map[string]interface{}))
-	expectedAnnotations := makeExpectedAnnotations(t, roleConfig["additional_metadata"].(map[string]interface{}))
+	expectedLabels := makeExpectedLabels(t, asMapString(roleConfig["extra_labels"].(map[string]interface{})))
+	expectedAnnotations := asMapString(roleConfig["extra_annotations"].(map[string]interface{}))
 
 	k8sClient := newK8sClient(t, os.Getenv("SUPER_JWT"))
 	acct, err := k8sClient.CoreV1().ServiceAccounts("test").Get(context.Background(), objName, metav1.GetOptions{})
@@ -410,12 +409,8 @@ func makeRules(t *testing.T, rules string) []rbacv1.PolicyRule {
 	return policyRules.Rules
 }
 
-func makeExpectedLabels(t *testing.T, userMetadata map[string]interface{}) map[string]string {
+func makeExpectedLabels(t *testing.T, userLabels map[string]string) map[string]string {
 	t.Helper()
-
-	userLabels := map[string]string{}
-	err := mapstructure.Decode(userMetadata["labels"], &userLabels)
-	require.NoError(t, err)
 
 	expectedLabels := map[string]string{}
 	if userLabels != nil {
@@ -426,11 +421,20 @@ func makeExpectedLabels(t *testing.T, userMetadata map[string]interface{}) map[s
 	return expectedLabels
 }
 
-func makeExpectedAnnotations(t *testing.T, userMetadata map[string]interface{}) map[string]string {
-	t.Helper()
+func asMapInterface(m map[string]string) map[string]interface{} {
+	result := map[string]interface{}{}
+	for k, v := range m {
+		result[k] = v
+	}
 
-	expectedAnnotations := map[string]string{}
-	err := mapstructure.Decode(userMetadata["annotations"], &expectedAnnotations)
-	require.NoError(t, err)
-	return expectedAnnotations
+	return result
+}
+
+func asMapString(m map[string]interface{}) map[string]string {
+	result := map[string]string{}
+	for k, v := range m {
+		result[k] = v.(string)
+	}
+
+	return result
 }

--- a/integrationtest/integration_test.go
+++ b/integrationtest/integration_test.go
@@ -121,8 +121,9 @@ func TestRole(t *testing.T) {
 	result, err := client.Logical().Read(path + "/roles/testrole")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{
-		"additional_metadata":           map[string]interface{}{},
 		"allowed_kubernetes_namespaces": []interface{}{"*"},
+		"extra_annotations":             nil,
+		"extra_labels":                  nil,
 		"generated_role_rules":          sampleRules,
 		"kubernetes_role_name":          "",
 		"kubernetes_role_type":          "Role",
@@ -136,15 +137,17 @@ func TestRole(t *testing.T) {
 	// update
 	_, err = client.Logical().Write(path+"/roles/testrole", map[string]interface{}{
 		"allowed_kubernetes_namespaces": []string{"app1", "app2"},
-		"additional_metadata":           sampleMetadata,
+		"extra_annotations":             sampleExtraAnnotations,
+		"extra_labels":                  sampleExtraLabels,
 		"token_default_ttl":             "30m",
 	})
 
 	result, err = client.Logical().Read(path + "/roles/testrole")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{
-		"additional_metadata":           sampleMetadata,
 		"allowed_kubernetes_namespaces": []interface{}{"app1", "app2"},
+		"extra_annotations":             asMapInterface(sampleExtraAnnotations),
+		"extra_labels":                  asMapInterface(sampleExtraLabels),
 		"generated_role_rules":          sampleRules,
 		"kubernetes_role_name":          "",
 		"kubernetes_role_type":          "Role",
@@ -193,16 +196,16 @@ const sampleRules = `rules:
   verbs: ["get", "watch", "list"]
 `
 
-var sampleMetadata = map[string]interface{}{
-	"labels": map[string]interface{}{
+var (
+	sampleExtraLabels = map[string]string{
 		"key1": "value1",
 		"key2": "value2",
-	},
-	"annotations": map[string]interface{}{
+	}
+	sampleExtraAnnotations = map[string]string{
 		"key3": "value3",
 		"key4": "value4",
-	},
-}
+	}
+)
 
 const (
 	thirtyMinutes json.Number = "1800"

--- a/integrationtest/wal_rollback_test.go
+++ b/integrationtest/wal_rollback_test.go
@@ -168,8 +168,8 @@ func TestCreds_wal_rollback(t *testing.T) {
 		t.Log("Checking for hanging k8s objects")
 		checkObjects(t, roleConfig, true, true, 10*time.Second)
 
-		// The backend's WAL min age is 10 minutes. After that the k8s objects
-		// should be cleaned up.
+		// The backend's WAL min age is 10 seconds for tests. After that the k8s
+		// objects should be cleaned up.
 		t.Log("Checking hanging objects have been cleaned up")
 		checkObjects(t, roleConfig, true, false, 1*time.Minute)
 	})

--- a/integrationtest/wal_rollback_test.go
+++ b/integrationtest/wal_rollback_test.go
@@ -44,27 +44,27 @@ func TestCreds_wal_rollback(t *testing.T) {
   resources: ["pods"]
   verbs: ["list"]`
 
-		metadata := map[string]interface{}{
-			"labels": map[string]interface{}{
-				"environment": "testing",
-				"test":        "wal_rollback",
-				"type":        "role",
-			},
-			"annotations": map[string]interface{}{
-				"tested": "today",
-			},
+		extraLabels := map[string]string{
+			"environment": "testing",
+			"test":        "wal_rollback",
+			"type":        "role",
+		}
+		extraAnnotations := map[string]string{
+			"tested": "today",
 		}
 		roleConfig := map[string]interface{}{
-			"additional_metadata":           metadata,
 			"allowed_kubernetes_namespaces": []string{"test"},
+			"extra_annotations":             extraAnnotations,
+			"extra_labels":                  extraLabels,
 			"generated_role_rules":          roleRulesYAML,
 			"kubernetes_role_type":          "RolE",
 			"token_default_ttl":             "1h",
 			"token_max_ttl":                 "24h",
 		}
 		expectedRoleResponse := map[string]interface{}{
-			"additional_metadata":           metadata,
 			"allowed_kubernetes_namespaces": []interface{}{"test"},
+			"extra_annotations":             asMapInterface(extraAnnotations),
+			"extra_labels":                  asMapInterface(extraLabels),
 			"generated_role_rules":          roleRulesYAML,
 			"kubernetes_role_name":          "",
 			"kubernetes_role_type":          "Role",
@@ -112,28 +112,28 @@ func TestCreds_wal_rollback(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		metadata := map[string]interface{}{
-			"labels": map[string]interface{}{
-				"environment": "staging",
-				"test":        "wal_rollback",
-				"type":        "clusterrolebinding",
-			},
-			"annotations": map[string]interface{}{
-				"tested":  "tomorrow",
-				"checked": "again",
-			},
+		extraLabels := map[string]string{
+			"environment": "staging",
+			"test":        "wal_rollback",
+			"type":        "clusterrolebinding",
+		}
+		extraAnnotations := map[string]string{
+			"tested":  "tomorrow",
+			"checked": "again",
 		}
 		roleConfig := map[string]interface{}{
-			"additional_metadata":           metadata,
 			"allowed_kubernetes_namespaces": []string{"test"},
+			"extra_annotations":             extraAnnotations,
+			"extra_labels":                  extraLabels,
 			"kubernetes_role_name":          "test-cluster-role-list-pods",
 			"kubernetes_role_type":          "ClusterRole",
 			"token_default_ttl":             "1h",
 			"token_max_ttl":                 "24h",
 		}
 		expectedRoleResponse := map[string]interface{}{
-			"additional_metadata":           metadata,
 			"allowed_kubernetes_namespaces": []interface{}{"test"},
+			"extra_annotations":             asMapInterface(extraAnnotations),
+			"extra_labels":                  asMapInterface(extraLabels),
 			"generated_role_rules":          "",
 			"kubernetes_role_name":          "test-cluster-role-list-pods",
 			"kubernetes_role_type":          "ClusterRole",
@@ -182,7 +182,7 @@ func checkObjects(t *testing.T, roleConfig map[string]interface{}, isClusterBind
 	}
 
 	// Query by labels since we may not know the name
-	l := makeExpectedLabels(t, roleConfig["additional_metadata"].(map[string]interface{}))
+	l := makeExpectedLabels(t, roleConfig["extra_labels"].(map[string]string))
 	validatedSelector, err := labels.ValidatedSelectorFromSet(l)
 	require.NoError(t, err)
 	listOptions := metav1.ListOptions{
@@ -220,7 +220,7 @@ func verifyObjectsDeleted(t *testing.T, roleConfig map[string]interface{}, isClu
 	roleType := strings.ToLower(roleConfig["kubernetes_role_type"].(string))
 
 	// Query by labels since we may not know the name
-	l := makeExpectedLabels(t, roleConfig["additional_metadata"].(map[string]interface{}))
+	l := makeExpectedLabels(t, asMapString(roleConfig["extra_labels"].(map[string]interface{})))
 	validatedSelector, err := labels.ValidatedSelectorFromSet(l)
 	require.NoError(t, err)
 	listOptions := metav1.ListOptions{

--- a/integrationtest/wal_rollback_test.go
+++ b/integrationtest/wal_rollback_test.go
@@ -97,8 +97,8 @@ func TestCreds_wal_rollback(t *testing.T) {
 		t.Log("Checking for hanging k8s objects")
 		checkObjects(t, roleConfig, false, true, 10*time.Second)
 
-		// The backend's WAL min age is 10 minutes. After that the k8s objects
-		// should be cleaned up.
+		// The backend's WAL min age is 10 seconds for tests. After that the k8s
+		// objects should be cleaned up.
 		t.Log("Checking hanging objects have been cleaned up")
 		checkObjects(t, roleConfig, false, false, 1*time.Minute)
 	})

--- a/integrationtest/wal_rollback_test.go
+++ b/integrationtest/wal_rollback_test.go
@@ -28,7 +28,7 @@ func TestCreds_wal_rollback(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Run("generated_role_rules (takes 10 minutes)", func(t *testing.T) {
+	t.Run("generated_role_rules", func(t *testing.T) {
 		t.Parallel()
 		mountPath, umount := mountHelper(t, client)
 		defer umount()
@@ -94,14 +94,16 @@ func TestCreds_wal_rollback(t *testing.T) {
 		assert.Nil(t, credsResponse)
 		assert.Contains(t, err.Error(), `User "system:serviceaccount:test:broken-jwt" cannot create resource "serviceaccounts" in API group "" in the namespace "test"`)
 
-		checkObjects(t, roleConfig, false, true, 30*time.Second)
+		t.Log("Checking for hanging k8s objects")
+		checkObjects(t, roleConfig, false, true, 10*time.Second)
 
 		// The backend's WAL min age is 10 minutes. After that the k8s objects
 		// should be cleaned up.
-		checkObjects(t, roleConfig, false, false, 15*time.Minute)
+		t.Log("Checking hanging objects have been cleaned up")
+		checkObjects(t, roleConfig, false, false, 1*time.Minute)
 	})
 
-	t.Run("kubernetes_role_name (takes 10 minutes)", func(t *testing.T) {
+	t.Run("kubernetes_role_name", func(t *testing.T) {
 		t.Parallel()
 		mountPath, umount := mountHelper(t, client)
 		defer umount()
@@ -163,11 +165,13 @@ func TestCreds_wal_rollback(t *testing.T) {
 		assert.Nil(t, credsResponse)
 		assert.Contains(t, err.Error(), `User "system:serviceaccount:test:broken-jwt" cannot create resource "serviceaccounts" in API group "" in the namespace "test"`)
 
-		checkObjects(t, roleConfig, true, true, 30*time.Second)
+		t.Log("Checking for hanging k8s objects")
+		checkObjects(t, roleConfig, true, true, 10*time.Second)
 
 		// The backend's WAL min age is 10 minutes. After that the k8s objects
 		// should be cleaned up.
-		checkObjects(t, roleConfig, true, false, 15*time.Minute)
+		t.Log("Checking hanging objects have been cleaned up")
+		checkObjects(t, roleConfig, true, false, 1*time.Minute)
 	})
 }
 

--- a/path_config.go
+++ b/path_config.go
@@ -51,7 +51,7 @@ func (b *backend) pathConfig() *framework.Path {
 			},
 			"kubernetes_ca_cert": {
 				Type:        framework.TypeString,
-				Description: "PEM encoded CA certificate to use by the secret engine to verify the Kubernetes API server certificate. Defaults to the local pod's CA if found.",
+				Description: "PEM encoded CA certificate to use to verify the Kubernetes API server certificate. Defaults to the local pod's CA if found.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					Name: "Kubernetes CA Certificate",
 				},
@@ -65,7 +65,7 @@ func (b *backend) pathConfig() *framework.Path {
 			},
 			"service_account_jwt": {
 				Type:        framework.TypeString,
-				Description: "The JSON web token of the service account used by the secret engine to manage Kubernetes roles. Defaults to the local pod's JWT if found.",
+				Description: "The JSON web token of the service account used by the secret engine to manage Kubernetes credentials. Defaults to the local pod's JWT if found.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					Name: "Kubernetes API JWT",
 				},

--- a/path_creds.go
+++ b/path_creds.go
@@ -58,7 +58,7 @@ func (b *backend) pathCredentials() *framework.Path {
 			},
 			"kubernetes_namespace": {
 				Type:        framework.TypeString,
-				Description: "The name of the Kubernetes namespace in which to generate the service account",
+				Description: "The name of the Kubernetes namespace in which to generate the credentials",
 				Required:    true,
 			},
 			"cluster_role_binding": {

--- a/path_creds.go
+++ b/path_creds.go
@@ -269,7 +269,7 @@ func (b *backend) createCreds(ctx context.Context, req *logical.Request, role *r
 	createdTokenTTL, err := getTokenTTL(token)
 	switch {
 	case err != nil:
-		b.Logger().Warn(fmt.Sprintf("failed to read TTL of created Kubernetes token for %s/%s: %s", reqPayload.Namespace, genName, err))
+		return nil, fmt.Errorf("failed to read TTL of created Kubernetes token for %s/%s: %s", reqPayload.Namespace, genName, err)
 	case createdTokenTTL > theTTL:
 		respWarning = append(respWarning, fmt.Sprintf("the created Kubernetes service accout token TTL %v is greater than the Vault lease TTL %v", createdTokenTTL, theTTL))
 	case createdTokenTTL < theTTL:

--- a/path_roles.go
+++ b/path_roles.go
@@ -19,21 +19,17 @@ const (
 )
 
 type roleEntry struct {
-	Name               string        `json:"name" mapstructure:"name"`
-	K8sNamespaces      []string      `json:"allowed_kubernetes_namespaces" mapstructure:"allowed_kubernetes_namespaces"`
-	TokenMaxTTL        time.Duration `json:"token_max_ttl" mapstructure:"token_max_ttl"`
-	TokenDefaultTTL    time.Duration `json:"token_default_ttl" mapstructure:"token_default_ttl"`
-	ServiceAccountName string        `json:"service_account_name" mapstructure:"service_account_name"`
-	K8sRoleName        string        `json:"kubernetes_role_name" mapstructure:"kubernetes_role_name"`
-	K8sRoleType        string        `json:"kubernetes_role_type" mapstructure:"kubernetes_role_type"`
-	RoleRules          string        `json:"generated_role_rules" mapstructure:"generated_role_rules"`
-	NameTemplate       string        `json:"name_template" mapstructure:"name_template"`
-	Metadata           metadata      `json:"additional_metadata" mapstructure:"additional_metadata"`
-}
-
-type metadata struct {
-	Labels      map[string]string `json:"labels,omitempty" mapstructure:"labels,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty" mapstructure:"annotations,omitempty"`
+	Name               string            `json:"name" mapstructure:"name"`
+	K8sNamespaces      []string          `json:"allowed_kubernetes_namespaces" mapstructure:"allowed_kubernetes_namespaces"`
+	TokenMaxTTL        time.Duration     `json:"token_max_ttl" mapstructure:"token_max_ttl"`
+	TokenDefaultTTL    time.Duration     `json:"token_default_ttl" mapstructure:"token_default_ttl"`
+	ServiceAccountName string            `json:"service_account_name" mapstructure:"service_account_name"`
+	K8sRoleName        string            `json:"kubernetes_role_name" mapstructure:"kubernetes_role_name"`
+	K8sRoleType        string            `json:"kubernetes_role_type" mapstructure:"kubernetes_role_type"`
+	RoleRules          string            `json:"generated_role_rules" mapstructure:"generated_role_rules"`
+	NameTemplate       string            `json:"name_template" mapstructure:"name_template"`
+	ExtraLabels        map[string]string `json:"extra_labels" mapstructure:"extra_labels"`
+	ExtraAnnotations   map[string]string `json:"extra_annotations" mapstructure:"extra_annotations"`
 }
 
 func (r *roleEntry) toResponseData() (map[string]interface{}, error) {
@@ -99,9 +95,14 @@ func (b *backend) pathRoles() []*framework.Path {
 					Description: "The name template to use when generating service accounts, roles and role bindings. If unset, a default template is used.",
 					Required:    false,
 				},
-				"additional_metadata": {
-					Type:        framework.TypeMap,
-					Description: "Additional labels and annotations to apply to all generated object in Kubernetes.",
+				"extra_labels": {
+					Type:        framework.TypeKVPairs,
+					Description: "Additional labels to apply to all generated object in Kubernetes.",
+					Required:    false,
+				},
+				"extra_annotations": {
+					Type:        framework.TypeKVPairs,
+					Description: "Additional annotations to apply to all generated object in Kubernetes.",
 					Required:    false,
 				},
 			},
@@ -213,10 +214,11 @@ func (b *backend) pathRolesWrite(ctx context.Context, req *logical.Request, d *f
 	if nameTemplate, ok := d.GetOk("name_template"); ok {
 		entry.NameTemplate = nameTemplate.(string)
 	}
-	if metadata, ok := d.GetOk("additional_metadata"); ok {
-		if err := mapstructure.Decode(metadata, &entry.Metadata); err != nil {
-			return logical.ErrorResponse("additional_metadata should be a nested map, with only 'labels' and 'annotations' as the top level keys"), nil
-		}
+	if extraLabels, ok := d.GetOk("extra_labels"); ok {
+		entry.ExtraLabels = extraLabels.(map[string]string)
+	}
+	if extraAnnotations, ok := d.GetOk("extra_annotations"); ok {
+		entry.ExtraAnnotations = extraAnnotations.(map[string]string)
 	}
 
 	// Validate the entry

--- a/path_roles.go
+++ b/path_roles.go
@@ -56,22 +56,22 @@ func (b *backend) pathRoles() []*framework.Path {
 				},
 				"allowed_kubernetes_namespaces": {
 					Type:        framework.TypeCommaStringSlice,
-					Description: `A list of the valid Kubernetes namespaces in which this role can be used for creating service accounts. If set to "*" all namespaces are allowed.`,
+					Description: `A list of the Kubernetes namespaces in which credentials can be generated. If set to "*" all namespaces are allowed.`,
 					Required:    true,
 				},
 				"token_max_ttl": {
 					Type:        framework.TypeDurationSecond,
-					Description: "The maximum valid ttl for generated Kubernetes tokens. If not set or set to 0, will use system default.",
+					Description: "The maximum ttl for generated Kubernetes service account tokens. If not set or set to 0, will use system default.",
 					Required:    false,
 				},
 				"token_default_ttl": {
 					Type:        framework.TypeDurationSecond,
-					Description: "The default ttl for generated Kubernetes service accounts. If not set or set to 0, will use system default.",
+					Description: "The default ttl for generated Kubernetes service account tokens. If not set or set to 0, will use system default.",
 					Required:    false,
 				},
 				"service_account_name": {
 					Type:        framework.TypeString,
-					Description: "The pre-existing service account to generate tokens for. Mutually exclusive with all role parameters. If set, only a Kubernetes token will be created.",
+					Description: "The pre-existing service account to generate tokens for. Mutually exclusive with all role parameters. If set, only a Kubernetes service account token will be created.",
 					Required:    false,
 				},
 				"kubernetes_role_name": {
@@ -97,12 +97,12 @@ func (b *backend) pathRoles() []*framework.Path {
 				},
 				"extra_labels": {
 					Type:        framework.TypeKVPairs,
-					Description: "Additional labels to apply to all generated object in Kubernetes.",
+					Description: "Additional labels to apply to all generated Kubernetes objects.",
 					Required:    false,
 				},
 				"extra_annotations": {
 					Type:        framework.TypeKVPairs,
-					Description: "Additional annotations to apply to all generated object in Kubernetes.",
+					Description: "Additional annotations to apply to all generated Kubernetes objects.",
 					Required:    false,
 				},
 			},


### PR DESCRIPTION
Splits the `additional_metadata` parameter into two parameters, `extra_labels` and `extra_annotations`.

To set those from the CLI:

```bash
vault write kubernetes/roles/default \
    service_account_name=default \
    allowed_kubernetes_namespaces="*" \
    extra_labels=foo=bar \
    extra_annotations=baz=maz
```

Also spent some time speeding up the WAL tests which are now about ~20s in parallel on my machine, and 40-50s in CI:

```
--- PASS: TestCreds_wal_rollback (0.00s)
    --- PASS: TestCreds_wal_rollback/kubernetes_role_name (19.97s)
    --- PASS: TestCreds_wal_rollback/generated_role_rules (23.89s)
```