### PR TITLE
Backport 1.11: Split additional annotations (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## Unreleased
+
+### Changes
+
+* Split `additional_metadata` into `extra_annotations` and `extra_labels` parameters [[GH-7](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/pull/7)]
+
+## 0.1.0 (May 20th, 2022)
+
+Initial implementation [[GH-2](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/pull/2)][[GH-3](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/pull/3)][[GH-4](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/pull/4)]

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,16 @@ KIND_CLUSTER_NAME?=vault-plugin-secrets-kubernetes
 # kind k8s version
 KIND_K8S_VERSION?=v1.23.6
 
+PKG=github.com/hashicorp/vault-plugin-secrets-kubernetes
+LDFLAGS?="-X '$(PKG).WALRollbackMinAge=10s'"
+
 .PHONY: default
 default: dev
 
+# dev target sets WALRollbackMinAge to 10s instead of the default 10 minutes to speed up integration tests
 .PHONY: dev
 dev:
-	CGO_ENABLED=0 go build -o bin/vault-plugin-secrets-kubernetes cmd/vault-plugin-secrets-kubernetes/main.go
+	CGO_ENABLED=0 go build -ldflags $(LDFLAGS) -o bin/vault-plugin-secrets-kubernetes cmd/vault-plugin-secrets-kubernetes/main.go
 
 .PHONY: test
 test: fmtcheck

--- a/client.go
+++ b/client.go
@@ -63,13 +63,13 @@ func (c *client) createToken(ctx context.Context, namespace, name string, ttl ti
 
 func (c *client) createServiceAccount(ctx context.Context, namespace, name string, vaultRole *roleEntry, ownerRef metav1.OwnerReference) (*v1.ServiceAccount, error) {
 	// Set standardLabels last so that users can't override them
-	labels := combineMaps(vaultRole.Metadata.Labels, standardLabels)
+	labels := combineMaps(vaultRole.ExtraLabels, standardLabels)
 	serviceAccountConfig := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
 			Namespace:       namespace,
 			Labels:          labels,
-			Annotations:     vaultRole.Metadata.Annotations,
+			Annotations:     vaultRole.ExtraAnnotations,
 			OwnerReferences: []metav1.OwnerReference{ownerRef},
 		},
 	}
@@ -94,11 +94,11 @@ func (c *client) createRole(ctx context.Context, namespace, name string, vaultRo
 		return thisOwnerRef, err
 	}
 	// Set standardLabels last so that users can't override them
-	labels := combineMaps(vaultRole.Metadata.Labels, standardLabels)
+	labels := combineMaps(vaultRole.ExtraLabels, standardLabels)
 	objectMeta := metav1.ObjectMeta{
 		Name:        name,
 		Labels:      labels,
-		Annotations: vaultRole.Metadata.Annotations,
+		Annotations: vaultRole.ExtraAnnotations,
 	}
 
 	switch vaultRole.K8sRoleType {
@@ -154,11 +154,11 @@ func (c *client) createRoleBinding(ctx context.Context, namespace, name, k8sRole
 		Name:       name,
 	}
 	// Set standardLabels last so that users can't override them
-	labels := combineMaps(vaultRole.Metadata.Labels, standardLabels)
+	labels := combineMaps(vaultRole.ExtraLabels, standardLabels)
 	objectMeta := metav1.ObjectMeta{
 		Name:        name,
 		Labels:      labels,
-		Annotations: vaultRole.Metadata.Annotations,
+		Annotations: vaultRole.ExtraAnnotations,
 	}
 	if ownerRef != nil {
 		objectMeta.OwnerReferences = []metav1.OwnerReference{*ownerRef}

--- a/integrationtest/creds_integration_test.go
+++ b/integrationtest/creds_integration_test.go
@@ -145,8 +145,9 @@ func TestCreds_service_account_name(t *testing.T) {
 	roleResponse, err := client.Logical().Read(path + "/roles/testrole")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{
-		"additional_metadata":           map[string]interface{}{},
 		"allowed_kubernetes_namespaces": []interface{}{"*"},
+		"extra_labels":                  nil,
+		"extra_annotations":             nil,
 		"generated_role_rules":          "",
 		"kubernetes_role_name":          "",
 		"kubernetes_role_type":          "Role",
@@ -201,17 +202,16 @@ func TestCreds_kubernetes_role_name(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Role type", func(t *testing.T) {
-		metadata := map[string]interface{}{
-			"labels": map[string]interface{}{
-				"environment": "testing",
-			},
-			"annotations": map[string]interface{}{
-				"tested": "today",
-			},
+		extraLabels := map[string]string{
+			"environment": "testing",
+		}
+		extraAnnotations := map[string]string{
+			"tested": "today",
 		}
 		roleConfig := map[string]interface{}{
-			"additional_metadata":           metadata,
 			"allowed_kubernetes_namespaces": []string{"test"},
+			"extra_annotations":             extraAnnotations,
+			"extra_labels":                  extraLabels,
 			"kubernetes_role_name":          "test-role-list-pods",
 			"kubernetes_role_type":          "role",
 			"token_default_ttl":             "1h",
@@ -219,8 +219,9 @@ func TestCreds_kubernetes_role_name(t *testing.T) {
 			"name_template":                 `{{ printf "v-custom-name-%s" (random 24) | truncate 62 | lowercase }}`,
 		}
 		expectedRoleResponse := map[string]interface{}{
-			"additional_metadata":           metadata,
 			"allowed_kubernetes_namespaces": []interface{}{"test"},
+			"extra_annotations":             asMapInterface(extraAnnotations),
+			"extra_labels":                  asMapInterface(extraLabels),
 			"generated_role_rules":          "",
 			"kubernetes_role_name":          "test-role-list-pods",
 			"kubernetes_role_type":          "Role",
@@ -234,25 +235,25 @@ func TestCreds_kubernetes_role_name(t *testing.T) {
 	})
 
 	t.Run("ClusterRole type", func(t *testing.T) {
-		metadata := map[string]interface{}{
-			"labels": map[string]interface{}{
-				"environment": "staging",
-			},
-			"annotations": map[string]interface{}{
-				"tested": "tomorrow",
-			},
+		extraLabels := map[string]string{
+			"environment": "staging",
+		}
+		extraAnnotations := map[string]string{
+			"tested": "tomorrow",
 		}
 		roleConfig := map[string]interface{}{
-			"additional_metadata":           metadata,
 			"allowed_kubernetes_namespaces": []string{"test"},
+			"extra_annotations":             extraAnnotations,
+			"extra_labels":                  extraLabels,
 			"kubernetes_role_name":          "test-cluster-role-list-pods",
 			"kubernetes_role_type":          "Clusterrole",
 			"token_default_ttl":             "1h",
 			"token_max_ttl":                 "24h",
 		}
 		expectedRoleResponse := map[string]interface{}{
-			"additional_metadata":           metadata,
 			"allowed_kubernetes_namespaces": []interface{}{"test"},
+			"extra_annotations":             asMapInterface(extraAnnotations),
+			"extra_labels":                  asMapInterface(extraLabels),
 			"generated_role_rules":          "",
 			"kubernetes_role_name":          "test-cluster-role-list-pods",
 			"kubernetes_role_type":          "ClusterRole",
@@ -300,25 +301,25 @@ func TestCreds_generated_role_rules(t *testing.T) {
 ]`
 
 	t.Run("Role type", func(t *testing.T) {
-		metadata := map[string]interface{}{
-			"labels": map[string]interface{}{
-				"environment": "testing",
-			},
-			"annotations": map[string]interface{}{
-				"tested": "today",
-			},
+		extraLabels := map[string]string{
+			"environment": "testing",
+		}
+		extraAnnotations := map[string]string{
+			"tested": "today",
 		}
 		roleConfig := map[string]interface{}{
-			"additional_metadata":           metadata,
 			"allowed_kubernetes_namespaces": []string{"test"},
+			"extra_annotations":             extraAnnotations,
+			"extra_labels":                  extraLabels,
 			"generated_role_rules":          roleRulesYAML,
 			"kubernetes_role_type":          "RolE",
 			"token_default_ttl":             "1h",
 			"token_max_ttl":                 "24h",
 		}
 		expectedRoleResponse := map[string]interface{}{
-			"additional_metadata":           metadata,
 			"allowed_kubernetes_namespaces": []interface{}{"test"},
+			"extra_annotations":             asMapInterface(extraAnnotations),
+			"extra_labels":                  asMapInterface(extraLabels),
 			"generated_role_rules":          roleRulesYAML,
 			"kubernetes_role_name":          "",
 			"kubernetes_role_type":          "Role",
@@ -332,27 +333,27 @@ func TestCreds_generated_role_rules(t *testing.T) {
 	})
 
 	t.Run("ClusterRole type", func(t *testing.T) {
-		metadata := map[string]interface{}{
-			"labels": map[string]interface{}{
-				"environment": "staging",
-				"asdf":        "123",
-			},
-			"annotations": map[string]interface{}{
-				"tested":  "tomorrow",
-				"checked": "again",
-			},
+		extraLabels := map[string]string{
+			"environment": "staging",
+			"asdf":        "123",
+		}
+		extraAnnotations := map[string]string{
+			"tested":  "tomorrow",
+			"checked": "again",
 		}
 		roleConfig := map[string]interface{}{
-			"additional_metadata":           metadata,
 			"allowed_kubernetes_namespaces": []string{"test"},
+			"extra_annotations":             extraAnnotations,
+			"extra_labels":                  extraLabels,
 			"generated_role_rules":          roleRulesJSON,
 			"kubernetes_role_type":          "clusterRole",
 			"token_default_ttl":             "1h",
 			"token_max_ttl":                 "24h",
 		}
 		expectedRoleResponse := map[string]interface{}{
-			"additional_metadata":           metadata,
 			"allowed_kubernetes_namespaces": []interface{}{"test"},
+			"extra_annotations":             asMapInterface(extraAnnotations),
+			"extra_labels":                  asMapInterface(extraLabels),
 			"generated_role_rules":          roleRulesJSON,
 			"kubernetes_role_name":          "",
 			"kubernetes_role_type":          "ClusterRole",

--- a/integrationtest/integration_test.go
+++ b/integrationtest/integration_test.go
@@ -121,8 +121,9 @@ func TestRole(t *testing.T) {
 	result, err := client.Logical().Read(path + "/roles/testrole")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{
-		"additional_metadata":           map[string]interface{}{},
 		"allowed_kubernetes_namespaces": []interface{}{"*"},
+		"extra_annotations":             nil,
+		"extra_labels":                  nil,
 		"generated_role_rules":          sampleRules,
 		"kubernetes_role_name":          "",
 		"kubernetes_role_type":          "Role",
@@ -136,15 +137,17 @@ func TestRole(t *testing.T) {
 	// update
 	_, err = client.Logical().Write(path+"/roles/testrole", map[string]interface{}{
 		"allowed_kubernetes_namespaces": []string{"app1", "app2"},
-		"additional_metadata":           sampleMetadata,
+		"extra_annotations":             sampleExtraAnnotations,
+		"extra_labels":                  sampleExtraLabels,
 		"token_default_ttl":             "30m",
 	})
 
 	result, err = client.Logical().Read(path + "/roles/testrole")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{
-		"additional_metadata":           sampleMetadata,
 		"allowed_kubernetes_namespaces": []interface{}{"app1", "app2"},
+		"extra_annotations":             asMapInterface(sampleExtraAnnotations),
+		"extra_labels":                  asMapInterface(sampleExtraLabels),
 		"generated_role_rules":          sampleRules,
 		"kubernetes_role_name":          "",
 		"kubernetes_role_type":          "Role",
@@ -193,16 +196,16 @@ const sampleRules = `rules:
   verbs: ["get", "watch", "list"]
 `
 
-var sampleMetadata = map[string]interface{}{
-	"labels": map[string]interface{}{
+var (
+	sampleExtraLabels = map[string]string{
 		"key1": "value1",
 		"key2": "value2",
-	},
-	"annotations": map[string]interface{}{
+	}
+	sampleExtraAnnotations = map[string]string{
 		"key3": "value3",
 		"key4": "value4",
-	},
-}
+	}
+)
 
 const (
 	thirtyMinutes json.Number = "1800"

--- a/path_config.go
+++ b/path_config.go
@@ -51,7 +51,7 @@ func (b *backend) pathConfig() *framework.Path {
 			},
 			"kubernetes_ca_cert": {
 				Type:        framework.TypeString,
-				Description: "PEM encoded CA certificate to use by the secret engine to verify the Kubernetes API server certificate. Defaults to the local pod's CA if found.",
+				Description: "PEM encoded CA certificate to use to verify the Kubernetes API server certificate. Defaults to the local pod's CA if found.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					Name: "Kubernetes CA Certificate",
 				},
@@ -65,7 +65,7 @@ func (b *backend) pathConfig() *framework.Path {
 			},
 			"service_account_jwt": {
 				Type:        framework.TypeString,
-				Description: "The JSON web token of the service account used by the secret engine to manage Kubernetes roles. Defaults to the local pod's JWT if found.",
+				Description: "The JSON web token of the service account used by the secret engine to manage Kubernetes credentials. Defaults to the local pod's JWT if found.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					Name: "Kubernetes API JWT",
 				},

--- a/path_creds.go
+++ b/path_creds.go
@@ -58,7 +58,7 @@ func (b *backend) pathCredentials() *framework.Path {
 			},
 			"kubernetes_namespace": {
 				Type:        framework.TypeString,
-				Description: "The name of the Kubernetes namespace in which to generate the service account",
+				Description: "The name of the Kubernetes namespace in which to generate the credentials",
 				Required:    true,
 			},
 			"cluster_role_binding": {
@@ -269,7 +269,7 @@ func (b *backend) createCreds(ctx context.Context, req *logical.Request, role *r
 	createdTokenTTL, err := getTokenTTL(token)
 	switch {
 	case err != nil:
-		b.Logger().Warn(fmt.Sprintf("failed to read TTL of created Kubernetes token for %s/%s: %s", reqPayload.Namespace, genName, err))
+		return nil, fmt.Errorf("failed to read TTL of created Kubernetes token for %s/%s: %s", reqPayload.Namespace, genName, err)
 	case createdTokenTTL > theTTL:
 		respWarning = append(respWarning, fmt.Sprintf("the created Kubernetes service accout token TTL %v is greater than the Vault lease TTL %v", createdTokenTTL, theTTL))
 	case createdTokenTTL < theTTL:

--- a/path_roles.go
+++ b/path_roles.go
@@ -19,21 +19,17 @@ const (
 )
 
 type roleEntry struct {
-	Name               string        `json:"name" mapstructure:"name"`
-	K8sNamespaces      []string      `json:"allowed_kubernetes_namespaces" mapstructure:"allowed_kubernetes_namespaces"`
-	TokenMaxTTL        time.Duration `json:"token_max_ttl" mapstructure:"token_max_ttl"`
-	TokenDefaultTTL    time.Duration `json:"token_default_ttl" mapstructure:"token_default_ttl"`
-	ServiceAccountName string        `json:"service_account_name" mapstructure:"service_account_name"`
-	K8sRoleName        string        `json:"kubernetes_role_name" mapstructure:"kubernetes_role_name"`
-	K8sRoleType        string        `json:"kubernetes_role_type" mapstructure:"kubernetes_role_type"`
-	RoleRules          string        `json:"generated_role_rules" mapstructure:"generated_role_rules"`
-	NameTemplate       string        `json:"name_template" mapstructure:"name_template"`
-	Metadata           metadata      `json:"additional_metadata" mapstructure:"additional_metadata"`
-}
-
-type metadata struct {
-	Labels      map[string]string `json:"labels,omitempty" mapstructure:"labels,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty" mapstructure:"annotations,omitempty"`
+	Name               string            `json:"name" mapstructure:"name"`
+	K8sNamespaces      []string          `json:"allowed_kubernetes_namespaces" mapstructure:"allowed_kubernetes_namespaces"`
+	TokenMaxTTL        time.Duration     `json:"token_max_ttl" mapstructure:"token_max_ttl"`
+	TokenDefaultTTL    time.Duration     `json:"token_default_ttl" mapstructure:"token_default_ttl"`
+	ServiceAccountName string            `json:"service_account_name" mapstructure:"service_account_name"`
+	K8sRoleName        string            `json:"kubernetes_role_name" mapstructure:"kubernetes_role_name"`
+	K8sRoleType        string            `json:"kubernetes_role_type" mapstructure:"kubernetes_role_type"`
+	RoleRules          string            `json:"generated_role_rules" mapstructure:"generated_role_rules"`
+	NameTemplate       string            `json:"name_template" mapstructure:"name_template"`
+	ExtraLabels        map[string]string `json:"extra_labels" mapstructure:"extra_labels"`
+	ExtraAnnotations   map[string]string `json:"extra_annotations" mapstructure:"extra_annotations"`
 }
 
 func (r *roleEntry) toResponseData() (map[string]interface{}, error) {
@@ -60,22 +56,22 @@ func (b *backend) pathRoles() []*framework.Path {
 				},
 				"allowed_kubernetes_namespaces": {
 					Type:        framework.TypeCommaStringSlice,
-					Description: `A list of the valid Kubernetes namespaces in which this role can be used for creating service accounts. If set to "*" all namespaces are allowed.`,
+					Description: `A list of the Kubernetes namespaces in which credentials can be generated. If set to "*" all namespaces are allowed.`,
 					Required:    true,
 				},
 				"token_max_ttl": {
 					Type:        framework.TypeDurationSecond,
-					Description: "The maximum valid ttl for generated Kubernetes tokens. If not set or set to 0, will use system default.",
+					Description: "The maximum ttl for generated Kubernetes service account tokens. If not set or set to 0, will use system default.",
 					Required:    false,
 				},
 				"token_default_ttl": {
 					Type:        framework.TypeDurationSecond,
-					Description: "The default ttl for generated Kubernetes service accounts. If not set or set to 0, will use system default.",
+					Description: "The default ttl for generated Kubernetes service account tokens. If not set or set to 0, will use system default.",
 					Required:    false,
 				},
 				"service_account_name": {
 					Type:        framework.TypeString,
-					Description: "The pre-existing service account to generate tokens for. Mutually exclusive with all role parameters. If set, only a Kubernetes token will be created.",
+					Description: "The pre-existing service account to generate tokens for. Mutually exclusive with all role parameters. If set, only a Kubernetes service account token will be created.",
 					Required:    false,
 				},
 				"kubernetes_role_name": {
@@ -99,9 +95,14 @@ func (b *backend) pathRoles() []*framework.Path {
 					Description: "The name template to use when generating service accounts, roles and role bindings. If unset, a default template is used.",
 					Required:    false,
 				},
-				"additional_metadata": {
-					Type:        framework.TypeMap,
-					Description: "Additional labels and annotations to apply to all generated object in Kubernetes.",
+				"extra_labels": {
+					Type:        framework.TypeKVPairs,
+					Description: "Additional labels to apply to all generated Kubernetes objects.",
+					Required:    false,
+				},
+				"extra_annotations": {
+					Type:        framework.TypeKVPairs,
+					Description: "Additional annotations to apply to all generated Kubernetes objects.",
 					Required:    false,
 				},
 			},
@@ -213,10 +214,11 @@ func (b *backend) pathRolesWrite(ctx context.Context, req *logical.Request, d *f
 	if nameTemplate, ok := d.GetOk("name_template"); ok {
 		entry.NameTemplate = nameTemplate.(string)
 	}
-	if metadata, ok := d.GetOk("additional_metadata"); ok {
-		if err := mapstructure.Decode(metadata, &entry.Metadata); err != nil {
-			return logical.ErrorResponse("additional_metadata should be a nested map, with only 'labels' and 'annotations' as the top level keys"), nil
-		}
+	if extraLabels, ok := d.GetOk("extra_labels"); ok {
+		entry.ExtraLabels = extraLabels.(map[string]string)
+	}
+	if extraAnnotations, ok := d.GetOk("extra_annotations"); ok {
+		entry.ExtraAnnotations = extraAnnotations.(map[string]string)
 	}
 
 	// Validate the entry


### PR DESCRIPTION
Backporting #7 to the Vault 1.11 release branch.