### PR TITLE
Test with kubernetes 1.24

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,15 +54,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kind-k8s-version: [1.20.15, 1.21.12, 1.22.9, 1.23.6]
+        kind-k8s-version: [1.21.12, 1.22.9, 1.23.6, 1.24.1]
     steps:
       - uses: actions/checkout@v2
       - name: Create K8s Kind Cluster
         uses: helm/kind-action@v1.2.0
         with:
+          version: v0.14.0
           cluster_name: vault-plugin-secrets-kubernetes
           config: integrationtest/kind/config.yaml
           node_image: kindest/node:v${{ matrix.kind-k8s-version }}
+      # Must come _after_ kind-action, because the kind step also sets up a kubectl binary.
+      - uses: azure/setup-kubectl@v2.0
+        with:
+          version: 'v1.24.1'
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 KIND_CLUSTER_NAME?=vault-plugin-secrets-kubernetes
 
 # kind k8s version
-KIND_K8S_VERSION?=v1.23.6
+KIND_K8S_VERSION?=v1.24.1
 
 PKG=github.com/hashicorp/vault-plugin-secrets-kubernetes
 LDFLAGS?="-X '$(PKG).WALRollbackMinAge=10s'"


### PR DESCRIPTION
# Overview

Adds kubernetes 1.24 to the integration test matrix, drops 1.20 and updates the other versions, removes the unused KUBERNETES_JWT env.

# Design of Change

Similar to https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/152