### PR TITLE
Role namespace configuration possible via LabelSelector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
+### Improvements
+
 * Test against Vault Enterprise [[GH-11](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/pull/11)]
+* Role namespace configuration possible via LabelSelector [[GH-10](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/pull/10)]
 
 ## 0.1.1 (May 26th, 2022)
 

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ setup-integration-test-common: SET_LICENSE=$(if $(VAULT_LICENSE_CI),--set server
 setup-integration-test-common: teardown-integration-test
 	kind --name ${KIND_CLUSTER_NAME} load docker-image hashicorp/vault:dev
 	kubectl create namespace test
+	kubectl label namespaces test target=integration-test other=label
 
 	# don't log the license
 	printenv VAULT_LICENSE_CI > $(RUNNER_TEMP)/vault-license.txt || true

--- a/client.go
+++ b/client.go
@@ -216,6 +216,14 @@ func (c *client) deleteRoleBinding(ctx context.Context, namespace, name string, 
 	return nil
 }
 
+func (c *client) getNamespaceLabelSet(ctx context.Context, namespace string) (map[string]string, error) {
+	ns, err := c.k8s.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if err != nil {
+		return map[string]string{}, err
+	}
+	return ns.Labels, nil
+}
+
 func makeRules(rules string) ([]rbacv1.PolicyRule, error) {
 	policyRules := struct {
 		Rules []rbacv1.PolicyRule `json:"rules"`

--- a/client.go
+++ b/client.go
@@ -228,6 +228,16 @@ func makeRules(rules string) ([]rbacv1.PolicyRule, error) {
 	return policyRules.Rules, nil
 }
 
+func makeLabelSelector(selector string) (metav1.LabelSelector, error) {
+	labelSelector := metav1.LabelSelector{}
+	decoder := k8s_yaml.NewYAMLOrJSONDecoder(strings.NewReader(selector), len(selector))
+	err := decoder.Decode(&labelSelector)
+	if err != nil {
+		return labelSelector, err
+	}
+	return labelSelector, nil
+}
+
 func makeRoleType(roleType string) string {
 	switch strings.ToLower(roleType) {
 	case "role":

--- a/integrationtest/creds_integration_test.go
+++ b/integrationtest/creds_integration_test.go
@@ -149,17 +149,18 @@ func TestCreds_service_account_name(t *testing.T) {
 	roleResponse, err := client.Logical().Read(path + "/roles/testrole")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{
-		"allowed_kubernetes_namespaces": []interface{}{"*"},
-		"extra_labels":                  nil,
-		"extra_annotations":             nil,
-		"generated_role_rules":          "",
-		"kubernetes_role_name":          "",
-		"kubernetes_role_type":          "Role",
-		"name":                          "testrole",
-		"name_template":                 "",
-		"service_account_name":          "sample-app",
-		"token_max_ttl":                 oneDay,
-		"token_default_ttl":             oneHour,
+		"allowed_kubernetes_namespaces":         []interface{}{"*"},
+		"allowed_kubernetes_namespace_selector": "",
+		"extra_labels":                          nil,
+		"extra_annotations":                     nil,
+		"generated_role_rules":                  "",
+		"kubernetes_role_name":                  "",
+		"kubernetes_role_type":                  "Role",
+		"name":                                  "testrole",
+		"name_template":                         "",
+		"service_account_name":                  "sample-app",
+		"token_max_ttl":                         oneDay,
+		"token_default_ttl":                     oneHour,
 	}, roleResponse.Data)
 
 	result1, err := client.Logical().Write(path+"/creds/testrole", map[string]interface{}{
@@ -225,17 +226,18 @@ func TestCreds_kubernetes_role_name(t *testing.T) {
 			"name_template":                 `{{ printf "v-custom-name-%s" (random 24) | truncate 62 | lowercase }}`,
 		}
 		expectedRoleResponse := map[string]interface{}{
-			"allowed_kubernetes_namespaces": []interface{}{"test"},
-			"extra_annotations":             asMapInterface(extraAnnotations),
-			"extra_labels":                  asMapInterface(extraLabels),
-			"generated_role_rules":          "",
-			"kubernetes_role_name":          "test-role-list-pods",
-			"kubernetes_role_type":          "Role",
-			"name":                          "testrole",
-			"name_template":                 `{{ printf "v-custom-name-%s" (random 24) | truncate 62 | lowercase }}`,
-			"service_account_name":          "",
-			"token_max_ttl":                 oneDay,
-			"token_default_ttl":             oneHour,
+			"allowed_kubernetes_namespaces":         []interface{}{"test"},
+		  "allowed_kubernetes_namespace_selector": "",
+			"extra_annotations":                     asMapInterface(extraAnnotations),
+			"extra_labels":                          asMapInterface(extraLabels),
+			"generated_role_rules":                  "",
+			"kubernetes_role_name":                  "test-role-list-pods",
+			"kubernetes_role_type":                  "Role",
+			"name":                                  "testrole",
+			"name_template":                         `{{ printf "v-custom-name-%s" (random 24) | truncate 62 | lowercase }}`,
+			"service_account_name":                  "",
+			"token_max_ttl":                         oneDay,
+			"token_default_ttl":                     oneHour,
 		}
 		testRoleType(t, client, path, roleConfig, expectedRoleResponse)
 	})
@@ -257,17 +259,18 @@ func TestCreds_kubernetes_role_name(t *testing.T) {
 			"token_max_ttl":                 "24h",
 		}
 		expectedRoleResponse := map[string]interface{}{
-			"allowed_kubernetes_namespaces": []interface{}{"test"},
-			"extra_annotations":             asMapInterface(extraAnnotations),
-			"extra_labels":                  asMapInterface(extraLabels),
-			"generated_role_rules":          "",
-			"kubernetes_role_name":          "test-cluster-role-list-pods",
-			"kubernetes_role_type":          "ClusterRole",
-			"name":                          "clusterrole",
-			"name_template":                 "",
-			"service_account_name":          "",
-			"token_max_ttl":                 oneDay,
-			"token_default_ttl":             oneHour,
+			"allowed_kubernetes_namespaces":         []interface{}{"test"},
+		  "allowed_kubernetes_namespace_selector": "",
+			"extra_annotations":                     asMapInterface(extraAnnotations),
+			"extra_labels":                          asMapInterface(extraLabels),
+			"generated_role_rules":                  "",
+			"kubernetes_role_name":                  "test-cluster-role-list-pods",
+			"kubernetes_role_type":                  "ClusterRole",
+			"name":                                  "clusterrole",
+			"name_template":                         "",
+			"service_account_name":                  "",
+			"token_max_ttl":                         oneDay,
+			"token_default_ttl":                     oneHour,
 		}
 		testClusterRoleType(t, client, path, roleConfig, expectedRoleResponse)
 	})
@@ -325,17 +328,18 @@ func TestCreds_generated_role_rules(t *testing.T) {
 			"token_max_ttl":                 "24h",
 		}
 		expectedRoleResponse := map[string]interface{}{
-			"allowed_kubernetes_namespaces": []interface{}{"test"},
-			"extra_annotations":             asMapInterface(extraAnnotations),
-			"extra_labels":                  asMapInterface(extraLabels),
-			"generated_role_rules":          roleRulesYAML,
-			"kubernetes_role_name":          "",
-			"kubernetes_role_type":          "Role",
-			"name":                          "testrole",
-			"name_template":                 "",
-			"service_account_name":          "",
-			"token_max_ttl":                 oneDay,
-			"token_default_ttl":             oneHour,
+			"allowed_kubernetes_namespaces":         []interface{}{"test"},
+		  "allowed_kubernetes_namespace_selector": "",
+			"extra_annotations":                     asMapInterface(extraAnnotations),
+			"extra_labels":                          asMapInterface(extraLabels),
+			"generated_role_rules":                  roleRulesYAML,
+			"kubernetes_role_name":                  "",
+			"kubernetes_role_type":                  "Role",
+			"name":                                  "testrole",
+			"name_template":                         "",
+			"service_account_name":                  "",
+			"token_max_ttl":                         oneDay,
+			"token_default_ttl":                     oneHour,
 		}
 		testRoleType(t, client, path, roleConfig, expectedRoleResponse)
 	})
@@ -359,17 +363,18 @@ func TestCreds_generated_role_rules(t *testing.T) {
 			"token_max_ttl":                 "24h",
 		}
 		expectedRoleResponse := map[string]interface{}{
-			"allowed_kubernetes_namespaces": []interface{}{"test"},
-			"extra_annotations":             asMapInterface(extraAnnotations),
-			"extra_labels":                  asMapInterface(extraLabels),
-			"generated_role_rules":          roleRulesJSON,
-			"kubernetes_role_name":          "",
-			"kubernetes_role_type":          "ClusterRole",
-			"name":                          "clusterrole",
-			"name_template":                 "",
-			"service_account_name":          "",
-			"token_max_ttl":                 oneDay,
-			"token_default_ttl":             oneHour,
+			"allowed_kubernetes_namespaces":         []interface{}{"test"},
+		  "allowed_kubernetes_namespace_selector": "",
+			"extra_annotations":                     asMapInterface(extraAnnotations),
+			"extra_labels":                          asMapInterface(extraLabels),
+			"generated_role_rules":                  roleRulesJSON,
+			"kubernetes_role_name":                  "",
+			"kubernetes_role_type":                  "ClusterRole",
+			"name":                                  "clusterrole",
+			"name_template":                         "",
+			"service_account_name":                  "",
+			"token_max_ttl":                         oneDay,
+			"token_default_ttl":                     oneHour,
 		}
 		testClusterRoleType(t, client, path, roleConfig, expectedRoleResponse)
 	})

--- a/integrationtest/creds_integration_test.go
+++ b/integrationtest/creds_integration_test.go
@@ -227,7 +227,7 @@ func TestCreds_kubernetes_role_name(t *testing.T) {
 		}
 		expectedRoleResponse := map[string]interface{}{
 			"allowed_kubernetes_namespaces":         []interface{}{"test"},
-		  "allowed_kubernetes_namespace_selector": "",
+			"allowed_kubernetes_namespace_selector": "",
 			"extra_annotations":                     asMapInterface(extraAnnotations),
 			"extra_labels":                          asMapInterface(extraLabels),
 			"generated_role_rules":                  "",
@@ -250,17 +250,18 @@ func TestCreds_kubernetes_role_name(t *testing.T) {
 			"tested": "tomorrow",
 		}
 		roleConfig := map[string]interface{}{
-			"allowed_kubernetes_namespaces": []string{"test"},
-			"extra_annotations":             extraAnnotations,
-			"extra_labels":                  extraLabels,
-			"kubernetes_role_name":          "test-cluster-role-list-pods",
-			"kubernetes_role_type":          "Clusterrole",
-			"token_default_ttl":             "1h",
-			"token_max_ttl":                 "24h",
+			"allowed_kubernetes_namespaces":         []string{"random"},
+			"allowed_kubernetes_namespace_selector": `{"matchExpressions": [{"key": "target", "operator": "In", "values": ["integration-test"]}, {"key": "nonexistantlabel", "operator": "DoesNotExist", "values": []}]}`,
+			"extra_annotations":                     extraAnnotations,
+			"extra_labels":                          extraLabels,
+			"kubernetes_role_name":                  "test-cluster-role-list-pods",
+			"kubernetes_role_type":                  "Clusterrole",
+			"token_default_ttl":                     "1h",
+			"token_max_ttl":                         "24h",
 		}
 		expectedRoleResponse := map[string]interface{}{
-			"allowed_kubernetes_namespaces":         []interface{}{"test"},
-		  "allowed_kubernetes_namespace_selector": "",
+			"allowed_kubernetes_namespaces":         []interface{}{"random"},
+			"allowed_kubernetes_namespace_selector": `{"matchExpressions": [{"key": "target", "operator": "In", "values": ["integration-test"]}, {"key": "nonexistantlabel", "operator": "DoesNotExist", "values": []}]}`,
 			"extra_annotations":                     asMapInterface(extraAnnotations),
 			"extra_labels":                          asMapInterface(extraLabels),
 			"generated_role_rules":                  "",
@@ -329,7 +330,7 @@ func TestCreds_generated_role_rules(t *testing.T) {
 		}
 		expectedRoleResponse := map[string]interface{}{
 			"allowed_kubernetes_namespaces":         []interface{}{"test"},
-		  "allowed_kubernetes_namespace_selector": "",
+			"allowed_kubernetes_namespace_selector": "",
 			"extra_annotations":                     asMapInterface(extraAnnotations),
 			"extra_labels":                          asMapInterface(extraLabels),
 			"generated_role_rules":                  roleRulesYAML,
@@ -364,7 +365,7 @@ func TestCreds_generated_role_rules(t *testing.T) {
 		}
 		expectedRoleResponse := map[string]interface{}{
 			"allowed_kubernetes_namespaces":         []interface{}{"test"},
-		  "allowed_kubernetes_namespace_selector": "",
+			"allowed_kubernetes_namespace_selector": "",
 			"extra_annotations":                     asMapInterface(extraAnnotations),
 			"extra_labels":                          asMapInterface(extraLabels),
 			"generated_role_rules":                  roleRulesJSON,

--- a/integrationtest/integration_test.go
+++ b/integrationtest/integration_test.go
@@ -146,17 +146,18 @@ func TestRole(t *testing.T) {
 	result, err := client.Logical().Read(path + "/roles/testrole")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{
-		"allowed_kubernetes_namespaces": []interface{}{"*"},
-		"extra_annotations":             nil,
-		"extra_labels":                  nil,
-		"generated_role_rules":          sampleRules,
-		"kubernetes_role_name":          "",
-		"kubernetes_role_type":          "Role",
-		"name":                          "testrole",
-		"name_template":                 "",
-		"service_account_name":          "",
-		"token_max_ttl":                 oneDay,
-		"token_default_ttl":             oneHour,
+		"allowed_kubernetes_namespaces":         []interface{}{"*"},
+		"allowed_kubernetes_namespace_selector": "",
+		"extra_annotations":                     nil,
+		"extra_labels":                          nil,
+		"generated_role_rules":                  sampleRules,
+		"kubernetes_role_name":                  "",
+		"kubernetes_role_type":                  "Role",
+		"name":                                  "testrole",
+		"name_template":                         "",
+		"service_account_name":                  "",
+		"token_max_ttl":                         oneDay,
+		"token_default_ttl":                     oneHour,
 	}, result.Data)
 
 	// update
@@ -170,17 +171,18 @@ func TestRole(t *testing.T) {
 	result, err = client.Logical().Read(path + "/roles/testrole")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{
-		"allowed_kubernetes_namespaces": []interface{}{"app1", "app2"},
-		"extra_annotations":             asMapInterface(sampleExtraAnnotations),
-		"extra_labels":                  asMapInterface(sampleExtraLabels),
-		"generated_role_rules":          sampleRules,
-		"kubernetes_role_name":          "",
-		"kubernetes_role_type":          "Role",
-		"name":                          "testrole",
-		"name_template":                 "",
-		"service_account_name":          "",
-		"token_max_ttl":                 oneDay,
-		"token_default_ttl":             thirtyMinutes,
+		"allowed_kubernetes_namespaces":         []interface{}{"app1", "app2"},
+		"allowed_kubernetes_namespace_selector": "",
+		"extra_annotations":                     asMapInterface(sampleExtraAnnotations),
+		"extra_labels":                          asMapInterface(sampleExtraLabels),
+		"generated_role_rules":                  sampleRules,
+		"kubernetes_role_name":                  "",
+		"kubernetes_role_type":                  "Role",
+		"name":                                  "testrole",
+		"name_template":                         "",
+		"service_account_name":                  "",
+		"token_max_ttl":                         oneDay,
+		"token_default_ttl":                     thirtyMinutes,
 	}, result.Data)
 
 	result, err = client.Logical().List(path + "/roles")

--- a/integrationtest/integration_test.go
+++ b/integrationtest/integration_test.go
@@ -185,6 +185,29 @@ func TestRole(t *testing.T) {
 		"token_default_ttl":                     thirtyMinutes,
 	}, result.Data)
 
+	// update again
+	_, err = client.Logical().Write(path+"/roles/testrole", map[string]interface{}{
+		"allowed_kubernetes_namespaces":         []string{},
+		"allowed_kubernetes_namespace_selector": sampleSelector,
+	})
+
+	result, err = client.Logical().Read(path + "/roles/testrole")
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"allowed_kubernetes_namespaces":         []interface{}{},
+		"allowed_kubernetes_namespace_selector": sampleSelector,
+		"extra_annotations":                     asMapInterface(sampleExtraAnnotations),
+		"extra_labels":                          asMapInterface(sampleExtraLabels),
+		"generated_role_rules":                  sampleRules,
+		"kubernetes_role_name":                  "",
+		"kubernetes_role_type":                  "Role",
+		"name":                                  "testrole",
+		"name_template":                         "",
+		"service_account_name":                  "",
+		"token_max_ttl":                         oneDay,
+		"token_default_ttl":                     thirtyMinutes,
+	}, result.Data)
+
 	result, err = client.Logical().List(path + "/roles")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{"keys": []interface{}{"testrole"}}, result.Data)
@@ -287,11 +310,17 @@ func namespaceHelper(t *testing.T, client *api.Client) (*api.Client, func()) {
 	}
 }
 
-const sampleRules = `rules:
+const (
+	sampleRules = `rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "watch", "list"]
 `
+
+	sampleSelector = `matchLabels:
+  target: integration-test
+`
+)
 
 var (
 	sampleExtraLabels = map[string]string{

--- a/integrationtest/vault/testRoles.yaml
+++ b/integrationtest/vault/testRoles.yaml
@@ -10,14 +10,19 @@ rules:
   verbs:
   - create
 - apiGroups: [""]
-  resources: 
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups: [""]
+  resources:
   - serviceaccounts
   verbs:
   - create
   - delete
 - apiGroups:
   - rbac.authorization.k8s.io
-  resources: 
+  resources:
   - rolebindings
   - roles
   - clusterrolebindings
@@ -40,6 +45,12 @@ rules:
   - serviceaccounts/token
   verbs:
   - create
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/integrationtest/wal_rollback_test.go
+++ b/integrationtest/wal_rollback_test.go
@@ -65,17 +65,18 @@ func TestCreds_wal_rollback(t *testing.T) {
 			"token_max_ttl":                 "24h",
 		}
 		expectedRoleResponse := map[string]interface{}{
-			"allowed_kubernetes_namespaces": []interface{}{"test"},
-			"extra_annotations":             asMapInterface(extraAnnotations),
-			"extra_labels":                  asMapInterface(extraLabels),
-			"generated_role_rules":          roleRulesYAML,
-			"kubernetes_role_name":          "",
-			"kubernetes_role_type":          "Role",
-			"name":                          "walrole",
-			"name_template":                 "",
-			"service_account_name":          "",
-			"token_max_ttl":                 oneDay,
-			"token_default_ttl":             oneHour,
+			"allowed_kubernetes_namespaces":         []interface{}{"test"},
+		  "allowed_kubernetes_namespace_selector": "",
+			"extra_annotations":                     asMapInterface(extraAnnotations),
+			"extra_labels":                          asMapInterface(extraLabels),
+			"generated_role_rules":                  roleRulesYAML,
+			"kubernetes_role_name":                  "",
+			"kubernetes_role_type":                  "Role",
+			"name":                                  "walrole",
+			"name_template":                         "",
+			"service_account_name":                  "",
+			"token_max_ttl":                         oneDay,
+			"token_default_ttl":                     oneHour,
 		}
 
 		_, err := client.Logical().Write(mountPath+"/roles/walrole", roleConfig)
@@ -136,17 +137,18 @@ func TestCreds_wal_rollback(t *testing.T) {
 			"token_max_ttl":                 "24h",
 		}
 		expectedRoleResponse := map[string]interface{}{
-			"allowed_kubernetes_namespaces": []interface{}{"test"},
-			"extra_annotations":             asMapInterface(extraAnnotations),
-			"extra_labels":                  asMapInterface(extraLabels),
-			"generated_role_rules":          "",
-			"kubernetes_role_name":          "test-cluster-role-list-pods",
-			"kubernetes_role_type":          "ClusterRole",
-			"name":                          "walrolebinding",
-			"name_template":                 "",
-			"service_account_name":          "",
-			"token_max_ttl":                 oneDay,
-			"token_default_ttl":             oneHour,
+			"allowed_kubernetes_namespaces":         []interface{}{"test"},
+		  "allowed_kubernetes_namespace_selector": "",
+			"extra_annotations":                     asMapInterface(extraAnnotations),
+			"extra_labels":                          asMapInterface(extraLabels),
+			"generated_role_rules":                  "",
+			"kubernetes_role_name":                  "test-cluster-role-list-pods",
+			"kubernetes_role_type":                  "ClusterRole",
+			"name":                                  "walrolebinding",
+			"name_template":                         "",
+			"service_account_name":                  "",
+			"token_max_ttl":                         oneDay,
+			"token_default_ttl":                     oneHour,
 		}
 
 		_, err := client.Logical().Write(mountPath+"/roles/walrolebinding", roleConfig)

--- a/integrationtest/wal_rollback_test.go
+++ b/integrationtest/wal_rollback_test.go
@@ -66,7 +66,7 @@ func TestCreds_wal_rollback(t *testing.T) {
 		}
 		expectedRoleResponse := map[string]interface{}{
 			"allowed_kubernetes_namespaces":         []interface{}{"test"},
-		  "allowed_kubernetes_namespace_selector": "",
+			"allowed_kubernetes_namespace_selector": "",
 			"extra_annotations":                     asMapInterface(extraAnnotations),
 			"extra_labels":                          asMapInterface(extraLabels),
 			"generated_role_rules":                  roleRulesYAML,
@@ -128,17 +128,17 @@ func TestCreds_wal_rollback(t *testing.T) {
 			"checked": "again",
 		}
 		roleConfig := map[string]interface{}{
-			"allowed_kubernetes_namespaces": []string{"test"},
-			"extra_annotations":             extraAnnotations,
-			"extra_labels":                  extraLabels,
-			"kubernetes_role_name":          "test-cluster-role-list-pods",
-			"kubernetes_role_type":          "ClusterRole",
-			"token_default_ttl":             "1h",
-			"token_max_ttl":                 "24h",
+			"allowed_kubernetes_namespace_selector": `{"matchExpressions": [{"key": "target", "operator": "In", "values": ["integration-test"]}, {"key": "nonexistantlabel", "operator": "DoesNotExist", "values": []}]}`,
+			"extra_annotations":                     extraAnnotations,
+			"extra_labels":                          extraLabels,
+			"kubernetes_role_name":                  "test-cluster-role-list-pods",
+			"kubernetes_role_type":                  "ClusterRole",
+			"token_default_ttl":                     "1h",
+			"token_max_ttl":                         "24h",
 		}
 		expectedRoleResponse := map[string]interface{}{
-			"allowed_kubernetes_namespaces":         []interface{}{"test"},
-		  "allowed_kubernetes_namespace_selector": "",
+			"allowed_kubernetes_namespaces":         interface{}(nil),
+			"allowed_kubernetes_namespace_selector": `{"matchExpressions": [{"key": "target", "operator": "In", "values": ["integration-test"]}, {"key": "nonexistantlabel", "operator": "DoesNotExist", "values": []}]}`,
 			"extra_annotations":                     asMapInterface(extraAnnotations),
 			"extra_labels":                          asMapInterface(extraLabels),
 			"generated_role_rules":                  "",

--- a/path_roles.go
+++ b/path_roles.go
@@ -19,17 +19,18 @@ const (
 )
 
 type roleEntry struct {
-	Name               string            `json:"name" mapstructure:"name"`
-	K8sNamespaces      []string          `json:"allowed_kubernetes_namespaces" mapstructure:"allowed_kubernetes_namespaces"`
-	TokenMaxTTL        time.Duration     `json:"token_max_ttl" mapstructure:"token_max_ttl"`
-	TokenDefaultTTL    time.Duration     `json:"token_default_ttl" mapstructure:"token_default_ttl"`
-	ServiceAccountName string            `json:"service_account_name" mapstructure:"service_account_name"`
-	K8sRoleName        string            `json:"kubernetes_role_name" mapstructure:"kubernetes_role_name"`
-	K8sRoleType        string            `json:"kubernetes_role_type" mapstructure:"kubernetes_role_type"`
-	RoleRules          string            `json:"generated_role_rules" mapstructure:"generated_role_rules"`
-	NameTemplate       string            `json:"name_template" mapstructure:"name_template"`
-	ExtraLabels        map[string]string `json:"extra_labels" mapstructure:"extra_labels"`
-	ExtraAnnotations   map[string]string `json:"extra_annotations" mapstructure:"extra_annotations"`
+	Name                 string            `json:"name" mapstructure:"name"`
+	K8sNamespaces        []string          `json:"allowed_kubernetes_namespaces" mapstructure:"allowed_kubernetes_namespaces"`
+	K8sNamespaceSelector string            `json:"allowed_kubernetes_namespace_selector" mapstructure:"allowed_kubernetes_namespace_selector"`
+	TokenMaxTTL          time.Duration     `json:"token_max_ttl" mapstructure:"token_max_ttl"`
+	TokenDefaultTTL      time.Duration     `json:"token_default_ttl" mapstructure:"token_default_ttl"`
+	ServiceAccountName   string            `json:"service_account_name" mapstructure:"service_account_name"`
+	K8sRoleName          string            `json:"kubernetes_role_name" mapstructure:"kubernetes_role_name"`
+	K8sRoleType          string            `json:"kubernetes_role_type" mapstructure:"kubernetes_role_type"`
+	RoleRules            string            `json:"generated_role_rules" mapstructure:"generated_role_rules"`
+	NameTemplate         string            `json:"name_template" mapstructure:"name_template"`
+	ExtraLabels          map[string]string `json:"extra_labels" mapstructure:"extra_labels"`
+	ExtraAnnotations     map[string]string `json:"extra_annotations" mapstructure:"extra_annotations"`
 }
 
 func (r *roleEntry) toResponseData() (map[string]interface{}, error) {
@@ -57,7 +58,12 @@ func (b *backend) pathRoles() []*framework.Path {
 				"allowed_kubernetes_namespaces": {
 					Type:        framework.TypeCommaStringSlice,
 					Description: `A list of the Kubernetes namespaces in which credentials can be generated. If set to "*" all namespaces are allowed.`,
-					Required:    true,
+					Required:    false,
+				},
+				"allowed_kubernetes_namespace_selector": {
+					Type:        framework.TypeString,
+					Description: `A label selector in which credentials can be generated. Accepts either a JSON or YAML object.`,
+					Required:    false,
 				},
 				"token_max_ttl": {
 					Type:        framework.TypeDurationSecond,
@@ -188,6 +194,9 @@ func (b *backend) pathRolesWrite(ctx context.Context, req *logical.Request, d *f
 		// K8s namespaces need to be lowercase
 		entry.K8sNamespaces = strutil.RemoveDuplicates(k8sNamespaces.([]string), true)
 	}
+	if k8sNamespaceSelector, ok := d.GetOk("allowed_kubernetes_namespace_selector"); ok {
+		entry.K8sNamespaceSelector = k8sNamespaceSelector.(string)
+	}
 	if tokenMaxTTLRaw, ok := d.GetOk("token_max_ttl"); ok {
 		entry.TokenMaxTTL = time.Duration(tokenMaxTTLRaw.(int)) * time.Second
 	}
@@ -222,8 +231,8 @@ func (b *backend) pathRolesWrite(ctx context.Context, req *logical.Request, d *f
 	}
 
 	// Validate the entry
-	if len(entry.K8sNamespaces) == 0 {
-		return logical.ErrorResponse("allowed_kubernetes_namespaces must be set"), nil
+	if len(entry.K8sNamespaces) == 0 && entry.K8sNamespaceSelector == "" || len(entry.K8sNamespaces) != 0 && entry.K8sNamespaceSelector != "" {
+		return logical.ErrorResponse("one (and only one) of allowed_kubernetes_namespaces or allowed_kubernetes_namespace_selector must be set"), nil
 	}
 	if !onlyOneSet(entry.ServiceAccountName, entry.K8sRoleName, entry.RoleRules) {
 		return logical.ErrorResponse("one (and only one) of service_account_name, kubernetes_role_name or generated_role_rules must be set"), nil
@@ -237,6 +246,13 @@ func (b *backend) pathRolesWrite(ctx context.Context, req *logical.Request, d *f
 		return logical.ErrorResponse("kubernetes_role_type must be either 'Role' or 'ClusterRole'"), nil
 	}
 	entry.K8sRoleType = casedRoleType
+
+	// Try parsing the label selector as json or yaml
+	if entry.K8sNamespaceSelector != "" {
+		if _, err := makeLabelSelector(entry.K8sNamespaceSelector); err != nil {
+			return logical.ErrorResponse("failed to parse 'allowed_kubernetes_namespace_selector' as k8s.io/api/meta/v1/LabelSelector object"), nil
+		}
+	}
 
 	// Try parsing the role rules as json or yaml
 	if entry.RoleRules != "" {

--- a/path_roles.go
+++ b/path_roles.go
@@ -62,7 +62,7 @@ func (b *backend) pathRoles() []*framework.Path {
 				},
 				"allowed_kubernetes_namespace_selector": {
 					Type:        framework.TypeString,
-					Description: `A label selector in which credentials can be generated. Accepts either a JSON or YAML object.`,
+					Description: `A label selector for Kubernetes namespaces in which credentials can be generated. Accepts either a JSON or YAML object. If set with allowed_kubernetes_namespaces, the conditions are conjuncted.`,
 					Required:    false,
 				},
 				"token_max_ttl": {
@@ -231,8 +231,8 @@ func (b *backend) pathRolesWrite(ctx context.Context, req *logical.Request, d *f
 	}
 
 	// Validate the entry
-	if len(entry.K8sNamespaces) == 0 && entry.K8sNamespaceSelector == "" || len(entry.K8sNamespaces) != 0 && entry.K8sNamespaceSelector != "" {
-		return logical.ErrorResponse("one (and only one) of allowed_kubernetes_namespaces or allowed_kubernetes_namespace_selector must be set"), nil
+	if len(entry.K8sNamespaces) == 0 && entry.K8sNamespaceSelector == "" {
+		return logical.ErrorResponse("one (at least) of allowed_kubernetes_namespaces or allowed_kubernetes_namespace_selector must be set"), nil
 	}
 	if !onlyOneSet(entry.ServiceAccountName, entry.K8sRoleName, entry.RoleRules) {
 		return logical.ErrorResponse("one (and only one) of service_account_name, kubernetes_role_name or generated_role_rules must be set"), nil

--- a/path_roles_test.go
+++ b/path_roles_test.go
@@ -32,7 +32,21 @@ func TestRoles(t *testing.T) {
 			"service_account_name": "test_svc_account",
 		})
 		assert.NoError(t, err)
-		assert.EqualError(t, resp.Error(), "allowed_kubernetes_namespaces must be set")
+		assert.EqualError(t, resp.Error(), "one (and only one) of allowed_kubernetes_namespaces or allowed_kubernetes_namespace_selector must be set")
+
+		resp, err = testRoleCreate(t, b, s, "badrole", map[string]interface{}{
+			"allowed_kubernetes_namespace_selector": badYAMLSelector,
+			"kubernetes_role_name":                  "existing_role",
+		})
+		assert.NoError(t, err)
+		assert.EqualError(t, resp.Error(), "failed to parse 'allowed_kubernetes_namespace_selector' as k8s.io/api/meta/v1/LabelSelector object")
+
+		resp, err = testRoleCreate(t, b, s, "badrole", map[string]interface{}{
+			"allowed_kubernetes_namespace_selector": badJSONSelector,
+			"kubernetes_role_name":                  "existing_role",
+		})
+		assert.NoError(t, err)
+		assert.EqualError(t, resp.Error(), "failed to parse 'allowed_kubernetes_namespace_selector' as k8s.io/api/meta/v1/LabelSelector object")
 
 		resp, err = testRoleCreate(t, b, s, "badrole", map[string]interface{}{
 			"allowed_kubernetes_namespaces": []string{"app1", "app2"},
@@ -102,6 +116,61 @@ func TestRoles(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, resp.Data)
 
+		// Create one with json namespace label selector
+		resp, err = testRoleCreate(t, b, s, "jsonselector", map[string]interface{}{
+			"allowed_kubernetes_namespace_selector": goodJSONSelector,
+			"kubernetes_role_name":                  "existing_role",
+			"token_default_ttl":                     "5h",
+		})
+		assert.NoError(t, err)
+		assert.NoError(t, resp.Error())
+
+		resp, err = testRoleRead(t, b, s, "jsonselector")
+		require.NoError(t, err)
+		var nilMeta map[string]string
+		assert.Equal(t, map[string]interface{}{
+			"allowed_kubernetes_namespaces":         []string(nil),
+			"allowed_kubernetes_namespace_selector": goodJSONSelector,
+			"extra_labels":                          nilMeta,
+			"extra_annotations":                     nilMeta,
+			"generated_role_rules":                  "",
+			"kubernetes_role_name":                  "existing_role",
+			"kubernetes_role_type":                  "Role",
+			"name":                                  "jsonselector",
+			"name_template":                         "",
+			"service_account_name":                  "",
+			"token_max_ttl":                         time.Duration(0).Seconds(),
+			"token_default_ttl":                     time.Duration(time.Hour * 5).Seconds(),
+		}, resp.Data)
+
+		// Create one with yaml namespace selector and metadata
+		resp, err = testRoleCreate(t, b, s, "yamlselector", map[string]interface{}{
+			"allowed_kubernetes_namespace_selector": goodYAMLSelector,
+			"extra_annotations":                     testExtraAnnotations,
+			"extra_labels":                          testExtraLabels,
+			"kubernetes_role_name":                  "existing_role",
+			"kubernetes_role_type":                  "role",
+		})
+		assert.NoError(t, err)
+		assert.NoError(t, resp.Error())
+
+		resp, err = testRoleRead(t, b, s, "yamlselector")
+		require.NoError(t, err)
+		assert.Equal(t, map[string]interface{}{
+			"allowed_kubernetes_namespaces":         []string(nil),
+			"allowed_kubernetes_namespace_selector": goodYAMLSelector,
+			"extra_annotations":                     testExtraAnnotations,
+			"extra_labels":                          testExtraLabels,
+			"generated_role_rules":                  "",
+			"kubernetes_role_name":                  "existing_role",
+			"kubernetes_role_type":                  "Role",
+			"name":                                  "yamlselector",
+			"name_template":                         "",
+			"service_account_name":                  "",
+			"token_max_ttl":                         time.Duration(0).Seconds(),
+			"token_default_ttl":                     time.Duration(0).Seconds(),
+		}, resp.Data)
+
 		// Create one with json role rules
 		resp, err = testRoleCreate(t, b, s, "jsonrules", map[string]interface{}{
 			"allowed_kubernetes_namespaces": []string{"app1", "app2"},
@@ -113,19 +182,19 @@ func TestRoles(t *testing.T) {
 
 		resp, err = testRoleRead(t, b, s, "jsonrules")
 		require.NoError(t, err)
-		var nilMeta map[string]string
 		assert.Equal(t, map[string]interface{}{
-			"allowed_kubernetes_namespaces": []string{"app1", "app2"},
-			"extra_labels":                  nilMeta,
-			"extra_annotations":             nilMeta,
-			"generated_role_rules":          goodJSONRules,
-			"kubernetes_role_name":          "",
-			"kubernetes_role_type":          "Role",
-			"name":                          "jsonrules",
-			"name_template":                 "",
-			"service_account_name":          "",
-			"token_max_ttl":                 time.Duration(0).Seconds(),
-			"token_default_ttl":             time.Duration(time.Hour * 5).Seconds(),
+			"allowed_kubernetes_namespaces":         []string{"app1", "app2"},
+			"allowed_kubernetes_namespace_selector": "",
+			"extra_labels":                          nilMeta,
+			"extra_annotations":                     nilMeta,
+			"generated_role_rules":                  goodJSONRules,
+			"kubernetes_role_name":                  "",
+			"kubernetes_role_type":                  "Role",
+			"name":                                  "jsonrules",
+			"name_template":                         "",
+			"service_account_name":                  "",
+			"token_max_ttl":                         time.Duration(0).Seconds(),
+			"token_default_ttl":                     time.Duration(time.Hour * 5).Seconds(),
 		}, resp.Data)
 
 		// Create one with yaml role rules and metadata
@@ -142,17 +211,18 @@ func TestRoles(t *testing.T) {
 		resp, err = testRoleRead(t, b, s, "yamlrules")
 		require.NoError(t, err)
 		assert.Equal(t, map[string]interface{}{
-			"allowed_kubernetes_namespaces": []string{"app1", "app2"},
-			"extra_annotations":             testExtraAnnotations,
-			"extra_labels":                  testExtraLabels,
-			"generated_role_rules":          goodYAMLRules,
-			"kubernetes_role_name":          "",
-			"kubernetes_role_type":          "Role",
-			"name":                          "yamlrules",
-			"name_template":                 "",
-			"service_account_name":          "",
-			"token_max_ttl":                 time.Duration(0).Seconds(),
-			"token_default_ttl":             time.Duration(0).Seconds(),
+			"allowed_kubernetes_namespaces":         []string{"app1", "app2"},
+			"allowed_kubernetes_namespace_selector": "",
+			"extra_annotations":                     testExtraAnnotations,
+			"extra_labels":                          testExtraLabels,
+			"generated_role_rules":                  goodYAMLRules,
+			"kubernetes_role_name":                  "",
+			"kubernetes_role_type":                  "Role",
+			"name":                                  "yamlrules",
+			"name_template":                         "",
+			"service_account_name":                  "",
+			"token_max_ttl":                         time.Duration(0).Seconds(),
+			"token_default_ttl":                     time.Duration(0).Seconds(),
 		}, resp.Data)
 
 		// update yamlrules (with a duplicate namespace)
@@ -164,37 +234,42 @@ func TestRoles(t *testing.T) {
 		resp, err = testRoleRead(t, b, s, "yamlrules")
 		require.NoError(t, err)
 		assert.Equal(t, map[string]interface{}{
-			"allowed_kubernetes_namespaces": []string{"app3", "app4"},
-			"extra_annotations":             testExtraAnnotations,
-			"extra_labels":                  testExtraLabels,
-			"generated_role_rules":          goodYAMLRules,
-			"kubernetes_role_name":          "",
-			"kubernetes_role_type":          "Role",
-			"name":                          "yamlrules",
-			"name_template":                 "",
-			"service_account_name":          "",
-			"token_max_ttl":                 time.Duration(0).Seconds(),
-			"token_default_ttl":             time.Duration(0).Seconds(),
+			"allowed_kubernetes_namespaces":         []string{"app3", "app4"},
+			"allowed_kubernetes_namespace_selector": "",
+			"extra_annotations":                     testExtraAnnotations,
+			"extra_labels":                          testExtraLabels,
+			"generated_role_rules":                  goodYAMLRules,
+			"kubernetes_role_name":                  "",
+			"kubernetes_role_type":                  "Role",
+			"name":                                  "yamlrules",
+			"name_template":                         "",
+			"service_account_name":                  "",
+			"token_max_ttl":                         time.Duration(0).Seconds(),
+			"token_default_ttl":                     time.Duration(0).Seconds(),
 		}, resp.Data)
 
-		// Now there should be two roles returned from list
+		// Now there should be four roles returned from list
 		resp, err = testRolesList(t, b, s)
 		require.NoError(t, err)
 		assert.Equal(t, map[string]interface{}{
-			"keys": []string{"jsonrules", "yamlrules"},
+			"keys": []string{"jsonrules", "jsonselector", "yamlrules", "yamlselector"},
 		}, resp.Data)
 
 		// Delete one
 		resp, err = testRolesDelete(t, b, s, "jsonrules")
 		require.NoError(t, err)
-		// Now there should be one
+		// Now there should be three
 		resp, err = testRolesList(t, b, s)
 		require.NoError(t, err)
 		assert.Equal(t, map[string]interface{}{
-			"keys": []string{"yamlrules"},
+			"keys": []string{"jsonselector", "yamlrules", "yamlselector"},
 		}, resp.Data)
-		// Delete the last one
+		// Delete the last three
 		resp, err = testRolesDelete(t, b, s, "yamlrules")
+		require.NoError(t, err)
+		resp, err = testRolesDelete(t, b, s, "jsonselector")
+		require.NoError(t, err)
+		resp, err = testRolesDelete(t, b, s, "yamlselector")
 		require.NoError(t, err)
 		// Now there should be none
 		resp, err = testRolesList(t, b, s)
@@ -256,6 +331,28 @@ var (
 )
 
 const (
+	goodJSONSelector = `{
+	"matchLabels": {
+	  "stage": "prod",
+		"app": "vault"
+	}
+}`
+
+	badJSONSelector = `{
+	"matchLabels":
+	  "stage": "prod",
+		"app": "vault"
+}`
+
+	goodYAMLSelector = `matchLabels:
+  stage: prod
+  app: vault
+`
+	badYAMLSelector = `matchLabels:
+- stage: prod
+- app: vault
+`
+
 	goodJSONRules = `"rules": [
 	{
 		"apiGroups": [

--- a/path_roles_test.go
+++ b/path_roles_test.go
@@ -32,7 +32,7 @@ func TestRoles(t *testing.T) {
 			"service_account_name": "test_svc_account",
 		})
 		assert.NoError(t, err)
-		assert.EqualError(t, resp.Error(), "one (and only one) of allowed_kubernetes_namespaces or allowed_kubernetes_namespace_selector must be set")
+		assert.EqualError(t, resp.Error(), "one (at least) of allowed_kubernetes_namespaces or allowed_kubernetes_namespace_selector must be set")
 
 		resp, err = testRoleCreate(t, b, s, "badrole", map[string]interface{}{
 			"allowed_kubernetes_namespace_selector": badYAMLSelector,
@@ -118,6 +118,7 @@ func TestRoles(t *testing.T) {
 
 		// Create one with json namespace label selector
 		resp, err = testRoleCreate(t, b, s, "jsonselector", map[string]interface{}{
+			"allowed_kubernetes_namespaces":         []string{"test"},
 			"allowed_kubernetes_namespace_selector": goodJSONSelector,
 			"kubernetes_role_name":                  "existing_role",
 			"token_default_ttl":                     "5h",
@@ -129,7 +130,7 @@ func TestRoles(t *testing.T) {
 		require.NoError(t, err)
 		var nilMeta map[string]string
 		assert.Equal(t, map[string]interface{}{
-			"allowed_kubernetes_namespaces":         []string(nil),
+			"allowed_kubernetes_namespaces":         []string{"test"},
 			"allowed_kubernetes_namespace_selector": goodJSONSelector,
 			"extra_labels":                          nilMeta,
 			"extra_annotations":                     nilMeta,


### PR DESCRIPTION
# Overview

This PR implements the enhancement requested in hashicorp/vault#16222

It adds a `allowed_kubernetes_namespace_selector` parameter to the role declaration that allows to configure the allowed namespaces in which SAs can be created via a Kubernetes LabelSelector.

# Design of Change

See hashicorp/vault#16222

# Related Issues/Pull Requests

- [ ] [Issue #16222](https://github.com/hashicorp/vault/issues/16222)

# Contributor Checklist

- [x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet -> https://github.com/hashicorp/vault/pull/16240
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests) -> tests pass
- [x] Backwards compatible
