### PR TITLE
Add /check endpoint to verify env variable setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Add `/check` endpoint to determine if environment variables are set [GH-???](???)
+* Add `/check` endpoint to determine if environment variables are set [GH-18](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/pull/18)
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Add `/check` endpoint to determine if environment variables are set [GH-???](???)
+
 ### Changes
 
 * Update to Go 1.19 [GH-15](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/pull/15)

--- a/backend.go
+++ b/backend.go
@@ -87,6 +87,7 @@ func newBackend() (*backend, error) {
 			[]*framework.Path{
 				b.pathConfig(),
 				b.pathCredentials(),
+				b.pathCheck(),
 			},
 			b.pathRoles(),
 		),

--- a/integrationtest/integration_test.go
+++ b/integrationtest/integration_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"strings"

--- a/integrationtest/integration_test.go
+++ b/integrationtest/integration_test.go
@@ -68,6 +68,23 @@ func TestMount(t *testing.T) {
 	defer umount()
 }
 
+func TestCheckViability(t *testing.T) {
+	client, err := api.NewClient(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	path, umount := mountHelper(t, client)
+	defer umount()
+	client, delNamespace := namespaceHelper(t, client)
+	defer delNamespace()
+
+	// check
+	resp, err := client.Logical().ReadRaw(path + "/check")
+	assert.NoError(t, err)
+	assert.Equal(t, 204, resp.StatusCode)
+}
+
 func TestConfig(t *testing.T) {
 	// Pick up VAULT_ADDR and VAULT_TOKEN from env vars
 	client, err := api.NewClient(nil)

--- a/integrationtest/integration_test.go
+++ b/integrationtest/integration_test.go
@@ -82,7 +82,7 @@ func TestCheckViability(t *testing.T) {
 	// check
 	resp, err := client.Logical().ReadRaw(path + "/check")
 	assert.NoError(t, err)
-	assert.Equal(t, 204, resp.StatusCode)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
 
 func TestConfig(t *testing.T) {

--- a/path_check.go
+++ b/path_check.go
@@ -43,7 +43,7 @@ func (b *backend) pathCheckRead(_ context.Context, _ *logical.Request, _ *framew
 	if len(missing) == 0 {
 		return &logical.Response{
 			Data: map[string]interface{}{
-				logical.HTTPStatusCode: 204,
+				logical.HTTPStatusCode: http.StatusNoContent,
 			},
 		}, nil
 	}

--- a/path_check.go
+++ b/path_check.go
@@ -16,9 +16,7 @@ const (
 	checkHelpDescription = `Checks the Kubernetes configuration is valid, checking if required environment variables are set.`
 )
 
-var (
-	envVarsToCheck = []string{"KUBERNETES_SERVICE_HOST", "KUBERNETES_SERVICE_PORT_HTTPS"}
-)
+var envVarsToCheck = []string{"KUBERNETES_SERVICE_HOST", "KUBERNETES_SERVICE_PORT_HTTPS"}
 
 func (b *backend) pathCheck() *framework.Path {
 	return &framework.Path{

--- a/path_check.go
+++ b/path_check.go
@@ -1,0 +1,55 @@
+package kubesecrets
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+const (
+	checkPath            = "check"
+	checkHelpSynopsis    = `Checks the Kubernetes configuration is valid.`
+	checkHelpDescription = `Checks the Kubernetes configuration is valid, checking if required environment variables are set.`
+)
+
+var (
+	envVarsToCheck = []string{"KUBERNETES_SERVICE_HOST", "KUBERNETES_SERVICE_PORT_HTTPS"}
+)
+
+func (b *backend) pathCheck() *framework.Path {
+	return &framework.Path{
+		Pattern: checkPath + "/?$",
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.pathCheckRead,
+			},
+		},
+		HelpSynopsis:    checkHelpSynopsis,
+		HelpDescription: checkHelpDescription,
+	}
+}
+
+func (b *backend) pathCheckRead(_ context.Context, _ *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	var missing []string
+	for _, key := range envVarsToCheck {
+		val := os.Getenv(key)
+		if val == "" {
+			missing = append(missing, key)
+		}
+	}
+
+	if len(missing) == 0 {
+		return &logical.Response{
+			Data: map[string]interface{}{
+				logical.HTTPStatusCode: 204,
+			},
+		}, nil
+	}
+
+	missingText := strings.Join(missing, ", ")
+	return logical.ErrorResponse(fmt.Sprintf("Missing environment variables: %s", missingText)), nil
+}

--- a/path_check.go
+++ b/path_check.go
@@ -16,7 +16,7 @@ const (
 	checkHelpDescription = `Checks the Kubernetes configuration is valid, checking if required environment variables are set.`
 )
 
-var envVarsToCheck = []string{"KUBERNETES_SERVICE_HOST", "KUBERNETES_SERVICE_PORT_HTTPS"}
+var envVarsToCheck = []string{k8sServiceHostEnv, k8sServicePortEnv}
 
 func (b *backend) pathCheck() *framework.Path {
 	return &framework.Path{

--- a/path_check.go
+++ b/path_check.go
@@ -3,6 +3,7 @@ package kubesecrets
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 


### PR DESCRIPTION
Adds a `/check` endpoint that will return a 204 if the required environment variables are present, and otherwise returns a 400 with a list of what variables are missing.

I tested manually as well by loading the plugin into a Vault cluster outside of Kubernetes and seeing it returned a 400, and running it in a Kubernetes cluster and seeing it return a 204.