### PR TITLE
change test to use update operation after removal of create operation

### DIFF
--- a/path_config_test.go
+++ b/path_config_test.go
@@ -147,7 +147,7 @@ func Test_configWithDynamicValues(t *testing.T) {
 			}
 
 			req := &logical.Request{
-				Operation: logical.CreateOperation,
+				Operation: logical.UpdateOperation,
 				Path:      configPath,
 				Storage:   storage,
 				Data:      tc.config,


### PR DESCRIPTION
When reviewing the previous mr (#19) I missed a reference to the create operation in the test - I updated it to use the UpdateOperation instead.