### PR TITLE
feat: optional audiences field on token create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Features:
+* creds: New `audiences` option to set audiences for the k8s token created from the TokenRequest API [GH-24](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/pull/24)
+
 ### IMPROVEMENTS:
 
 * enable plugin multiplexing [GH-23](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/pull/23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## Unreleased
 
 Features:
-* creds: New `audiences` option to set audiences for the k8s token created from the TokenRequest API [GH-24](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/pull/24)
+* add `audiences` option to set audiences for the k8s token created from the TokenRequest API, and add `token_default_audiences` 
+option to set the default audiences on role write [GH-24](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/pull/24)
+
 
 ### IMPROVEMENTS:
 

--- a/client.go
+++ b/client.go
@@ -49,10 +49,11 @@ func newClient(config *kubeConfig) (*client, error) {
 	return &client{k8sClient}, nil
 }
 
-func (c *client) createToken(ctx context.Context, namespace, name string, ttl time.Duration) (*authenticationv1.TokenRequestStatus, error) {
+func (c *client) createToken(ctx context.Context, namespace, name string, ttl time.Duration, audiences []string) (*authenticationv1.TokenRequestStatus, error) {
 	intTTL := int64(ttl.Seconds())
 	resp, err := c.k8s.CoreV1().ServiceAccounts(namespace).CreateToken(ctx, name, &authenticationv1.TokenRequest{
 		Spec: authenticationv1.TokenRequestSpec{
+			Audiences:         audiences,
 			ExpirationSeconds: &intTTL,
 		},
 	}, metav1.CreateOptions{})

--- a/client.go
+++ b/client.go
@@ -53,8 +53,8 @@ func (c *client) createToken(ctx context.Context, namespace, name string, ttl ti
 	intTTL := int64(ttl.Seconds())
 	resp, err := c.k8s.CoreV1().ServiceAccounts(namespace).CreateToken(ctx, name, &authenticationv1.TokenRequest{
 		Spec: authenticationv1.TokenRequestSpec{
-			Audiences:         audiences,
 			ExpirationSeconds: &intTTL,
+			Audiences:         audiences,
 		},
 	}, metav1.CreateOptions{})
 	if err != nil {

--- a/integrationtest/creds_integration_test.go
+++ b/integrationtest/creds_integration_test.go
@@ -156,9 +156,9 @@ func TestCreds_audiences(t *testing.T) {
 			},
 			credsConfig: map[string]interface{}{
 				"kubernetes_namespace": "test",
-				"audiences":            "vault,foobar",
+				"audiences":            "foo,bar",
 			},
-			expectedAudiences: []string{"vault", "foobar"},
+			expectedAudiences: []string{"foo", "bar"},
 		},
 		"audiences not set": {
 			roleConfig: map[string]interface{}{
@@ -182,11 +182,7 @@ func TestCreds_audiences(t *testing.T) {
 			assert.NoError(t, err)
 			require.NotNil(t, creds)
 
-			audiences := creds.Data["service_account_token_audiences"].([]interface{})
-			assert.Equal(t, len(tc.expectedAudiences), len(audiences))
-			for _, audience := range audiences {
-				assert.Contains(t, tc.expectedAudiences, audience.(string))
-			}
+			testK8sTokenAudiences(t, tc.expectedAudiences, creds.Data["service_account_token"].(string))
 		})
 		i = i + 1
 	}

--- a/integrationtest/creds_integration_test.go
+++ b/integrationtest/creds_integration_test.go
@@ -172,7 +172,7 @@ func TestCreds_audiences(t *testing.T) {
 			},
 			expectedAudiences: []interface{}{"foo", "bar"},
 		},
-		"default to audiences of k8s cluster setup if both not set": {
+		"default to audiences of k8s cluster default if both not set": {
 			roleConfig: map[string]interface{}{
 				"allowed_kubernetes_namespaces": []string{"*"},
 				"service_account_name":          "sample-app",

--- a/integrationtest/creds_integration_test.go
+++ b/integrationtest/creds_integration_test.go
@@ -145,22 +145,34 @@ func TestCreds_audiences(t *testing.T) {
 	type testCase struct {
 		roleConfig        map[string]interface{}
 		credsConfig       map[string]interface{}
-		expectedAudiences []string
+		expectedAudiences []interface{}
 	}
 
 	tests := map[string]testCase{
-		"audiences set": {
+		"both set": {
 			roleConfig: map[string]interface{}{
 				"allowed_kubernetes_namespaces": []string{"*"},
 				"service_account_name":          "sample-app",
+				"token_default_audiences":       []string{"foo", "bar"},
 			},
 			credsConfig: map[string]interface{}{
 				"kubernetes_namespace": "test",
-				"audiences":            "foo,bar",
+				"audiences":            "baz,qux",
 			},
-			expectedAudiences: []string{"foo", "bar"},
+			expectedAudiences: []interface{}{"baz", "qux"},
 		},
-		"audiences not set": {
+		"default to token_default_audiences": {
+			roleConfig: map[string]interface{}{
+				"allowed_kubernetes_namespaces": []string{"*"},
+				"service_account_name":          "sample-app",
+				"token_default_audiences":       []string{"foo", "bar"},
+			},
+			credsConfig: map[string]interface{}{
+				"kubernetes_namespace": "test",
+			},
+			expectedAudiences: []interface{}{"foo", "bar"},
+		},
+		"default to audiences of k8s cluster setup if both not set": {
 			roleConfig: map[string]interface{}{
 				"allowed_kubernetes_namespaces": []string{"*"},
 				"service_account_name":          "sample-app",
@@ -168,7 +180,7 @@ func TestCreds_audiences(t *testing.T) {
 			credsConfig: map[string]interface{}{
 				"kubernetes_namespace": "test",
 			},
-			expectedAudiences: []string{},
+			expectedAudiences: []interface{}{"https://kubernetes.default.svc.cluster.local"},
 		},
 	}
 	i := 0
@@ -227,6 +239,7 @@ func TestCreds_service_account_name(t *testing.T) {
 		"service_account_name":                  "sample-app",
 		"token_max_ttl":                         oneDay,
 		"token_default_ttl":                     oneHour,
+		"token_default_audiences":               nil,
 	}, roleResponse.Data)
 
 	result1, err := client.Logical().Write(path+"/creds/testrole", map[string]interface{}{
@@ -304,6 +317,7 @@ func TestCreds_kubernetes_role_name(t *testing.T) {
 			"service_account_name":                  "",
 			"token_max_ttl":                         oneDay,
 			"token_default_ttl":                     oneHour,
+			"token_default_audiences":               nil,
 		}
 		testRoleType(t, client, path, roleConfig, expectedRoleResponse)
 	})
@@ -338,6 +352,7 @@ func TestCreds_kubernetes_role_name(t *testing.T) {
 			"service_account_name":                  "",
 			"token_max_ttl":                         oneDay,
 			"token_default_ttl":                     oneHour,
+			"token_default_audiences":               nil,
 		}
 		testClusterRoleType(t, client, path, roleConfig, expectedRoleResponse)
 	})
@@ -407,6 +422,7 @@ func TestCreds_generated_role_rules(t *testing.T) {
 			"service_account_name":                  "",
 			"token_max_ttl":                         oneDay,
 			"token_default_ttl":                     oneHour,
+			"token_default_audiences":               nil,
 		}
 		testRoleType(t, client, path, roleConfig, expectedRoleResponse)
 	})
@@ -442,6 +458,7 @@ func TestCreds_generated_role_rules(t *testing.T) {
 			"service_account_name":                  "",
 			"token_max_ttl":                         oneDay,
 			"token_default_ttl":                     oneHour,
+			"token_default_audiences":               nil,
 		}
 		testClusterRoleType(t, client, path, roleConfig, expectedRoleResponse)
 	})

--- a/integrationtest/helpers.go
+++ b/integrationtest/helpers.go
@@ -390,6 +390,18 @@ func testK8sTokenTTL(t *testing.T, expectedSec int, token string) {
 	assert.Equal(t, expectedSec, int(exp-iat))
 }
 
+func testK8sTokenAudiences(t *testing.T, expectedAudiences []string, token string) {
+	parsed, err := josejwt.ParseSigned(token)
+	require.NoError(t, err)
+	claims := map[string]interface{}{}
+	err = parsed.UnsafeClaimsWithoutVerification(&claims)
+	require.NoError(t, err)
+	aud := claims["aud"].([]interface{})
+	for _, audience := range expectedAudiences {
+		assert.Contains(t, aud, interface{}(audience))
+	}
+}
+
 func combineMaps(maps ...map[string]string) map[string]string {
 	newMap := make(map[string]string)
 	for _, m := range maps {

--- a/integrationtest/helpers.go
+++ b/integrationtest/helpers.go
@@ -397,10 +397,7 @@ func testK8sTokenAudiences(t *testing.T, expectedAudiences []interface{}, token 
 	err = parsed.UnsafeClaimsWithoutVerification(&claims)
 	require.NoError(t, err)
 	aud := claims["aud"].([]interface{})
-	assert.Equal(t, len(expectedAudiences), len(aud))
-	for _, expectedAudience := range expectedAudiences {
-		assert.Contains(t, aud, expectedAudience)
-	}
+	assert.ElementsMatch(t, expectedAudiences, aud)
 }
 
 func combineMaps(maps ...map[string]string) map[string]string {

--- a/integrationtest/helpers.go
+++ b/integrationtest/helpers.go
@@ -390,15 +390,16 @@ func testK8sTokenTTL(t *testing.T, expectedSec int, token string) {
 	assert.Equal(t, expectedSec, int(exp-iat))
 }
 
-func testK8sTokenAudiences(t *testing.T, expectedAudiences []string, token string) {
+func testK8sTokenAudiences(t *testing.T, expectedAudiences []interface{}, token string) {
 	parsed, err := josejwt.ParseSigned(token)
 	require.NoError(t, err)
 	claims := map[string]interface{}{}
 	err = parsed.UnsafeClaimsWithoutVerification(&claims)
 	require.NoError(t, err)
 	aud := claims["aud"].([]interface{})
-	for _, audience := range expectedAudiences {
-		assert.Contains(t, aud, interface{}(audience))
+	assert.Equal(t, len(expectedAudiences), len(aud))
+	for _, expectedAudience := range expectedAudiences {
+		assert.Contains(t, aud, expectedAudience)
 	}
 }
 

--- a/integrationtest/integration_test.go
+++ b/integrationtest/integration_test.go
@@ -162,6 +162,7 @@ func TestRole(t *testing.T) {
 		"generated_role_rules":          sampleRules,
 		"token_default_ttl":             "1h",
 		"token_max_ttl":                 "24h",
+		"token_default_audiences":       []string{"foobar"},
 	})
 	assert.NoError(t, err)
 
@@ -180,6 +181,7 @@ func TestRole(t *testing.T) {
 		"service_account_name":                  "",
 		"token_max_ttl":                         oneDay,
 		"token_default_ttl":                     oneHour,
+		"token_default_audiences":               []interface{}{"foobar"},
 	}, result.Data)
 
 	// update
@@ -188,6 +190,7 @@ func TestRole(t *testing.T) {
 		"extra_annotations":             sampleExtraAnnotations,
 		"extra_labels":                  sampleExtraLabels,
 		"token_default_ttl":             "30m",
+		"token_default_audiences":       []string{"bar"},
 	})
 
 	result, err = client.Logical().Read(path + "/roles/testrole")
@@ -205,6 +208,7 @@ func TestRole(t *testing.T) {
 		"service_account_name":                  "",
 		"token_max_ttl":                         oneDay,
 		"token_default_ttl":                     thirtyMinutes,
+		"token_default_audiences":               []interface{}{"bar"},
 	}, result.Data)
 
 	// update again
@@ -228,6 +232,7 @@ func TestRole(t *testing.T) {
 		"service_account_name":                  "",
 		"token_max_ttl":                         oneDay,
 		"token_default_ttl":                     thirtyMinutes,
+		"token_default_audiences":               []interface{}{"bar"},
 	}, result.Data)
 
 	result, err = client.Logical().List(path + "/roles")

--- a/integrationtest/wal_rollback_test.go
+++ b/integrationtest/wal_rollback_test.go
@@ -66,6 +66,7 @@ func TestCreds_wal_rollback(t *testing.T) {
 			"kubernetes_role_type":          "RolE",
 			"token_default_ttl":             "1h",
 			"token_max_ttl":                 "24h",
+			"token_default_audiences":       []string{"foobar"},
 		}
 		expectedRoleResponse := map[string]interface{}{
 			"allowed_kubernetes_namespaces":         []interface{}{"test"},
@@ -80,6 +81,7 @@ func TestCreds_wal_rollback(t *testing.T) {
 			"service_account_name":                  "",
 			"token_max_ttl":                         oneDay,
 			"token_default_ttl":                     oneHour,
+			"token_default_audiences":               []interface{}{"foobar"},
 		}
 
 		_, err := client.Logical().Write(mountPath+"/roles/walrole", roleConfig)
@@ -138,6 +140,7 @@ func TestCreds_wal_rollback(t *testing.T) {
 			"kubernetes_role_type":                  "ClusterRole",
 			"token_default_ttl":                     "1h",
 			"token_max_ttl":                         "24h",
+			"token_default_audiences":               []string{"foobar"},
 		}
 		expectedRoleResponse := map[string]interface{}{
 			"allowed_kubernetes_namespaces":         interface{}(nil),
@@ -152,6 +155,7 @@ func TestCreds_wal_rollback(t *testing.T) {
 			"service_account_name":                  "",
 			"token_max_ttl":                         oneDay,
 			"token_default_ttl":                     oneHour,
+			"token_default_audiences":               []interface{}{"foobar"},
 		}
 
 		_, err := client.Logical().Write(mountPath+"/roles/walrolebinding", roleConfig)

--- a/path_creds.go
+++ b/path_creds.go
@@ -38,6 +38,7 @@ type credsRequest struct {
 	ClusterRoleBinding bool          `json:"cluster_role_binding"`
 	TTL                time.Duration `json:"ttl"`
 	RoleName           string        `json:"role_name"`
+	Audiences          []string      `json:"audiences"`
 }
 
 // The fields in nameMetadata are used for templated name generation
@@ -72,6 +73,10 @@ func (b *backend) pathCredentials() *framework.Path {
 			"ttl": {
 				Type:        framework.TypeDurationSecond,
 				Description: "The TTL of the generated credentials",
+			},
+			"audiences": {
+				Type:        framework.TypeCommaStringSlice,
+				Description: "The intended audiences of the generated credentials",
 			},
 		},
 
@@ -110,6 +115,11 @@ func (b *backend) pathCredentialsRead(ctx context.Context, req *logical.Request,
 	ttlRaw, ok := d.GetOk("ttl")
 	if ok {
 		request.TTL = time.Duration(ttlRaw.(int)) * time.Second
+	}
+
+	audiences, ok := d.Get("audiences").([]string)
+	if ok {
+		request.Audiences = audiences
 	}
 
 	// Validate the request
@@ -218,7 +228,7 @@ func (b *backend) createCreds(ctx context.Context, req *logical.Request, role *r
 	switch {
 	case role.ServiceAccountName != "":
 		// Create token for existing service account
-		status, err := client.createToken(ctx, reqPayload.Namespace, role.ServiceAccountName, theTTL)
+		status, err := client.createToken(ctx, reqPayload.Namespace, role.ServiceAccountName, theTTL, reqPayload.Audiences)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create a service account token for %s/%s: %s", reqPayload.Namespace, role.ServiceAccountName, err)
 		}
@@ -240,7 +250,7 @@ func (b *backend) createCreds(ctx context.Context, req *logical.Request, role *r
 			return nil, err
 		}
 
-		status, err := client.createToken(ctx, reqPayload.Namespace, genName, theTTL)
+		status, err := client.createToken(ctx, reqPayload.Namespace, genName, theTTL, reqPayload.Audiences)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create a service account token for %s/%s: %s", reqPayload.Namespace, genName, err)
 		}
@@ -267,7 +277,7 @@ func (b *backend) createCreds(ctx context.Context, req *logical.Request, role *r
 			return nil, err
 		}
 
-		status, err := client.createToken(ctx, reqPayload.Namespace, genName, theTTL)
+		status, err := client.createToken(ctx, reqPayload.Namespace, genName, theTTL, reqPayload.Audiences)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create a service account token for %s/%s: %s", reqPayload.Namespace, genName, err)
 		}
@@ -282,9 +292,10 @@ func (b *backend) createCreds(ctx context.Context, req *logical.Request, role *r
 	}
 
 	resp := b.Secret(kubeTokenType).Response(map[string]interface{}{
-		"service_account_namespace": reqPayload.Namespace,
-		"service_account_name":      serviceAccountName,
-		"service_account_token":     token,
+		"service_account_namespace":       reqPayload.Namespace,
+		"service_account_name":            serviceAccountName,
+		"service_account_token":           token,
+		"service_account_token_audiences": reqPayload.Audiences,
 	}, map[string]interface{}{
 		// the internal data is whatever we need to cleanup on revoke
 		// (service_account_name, role, role_binding).

--- a/path_creds.go
+++ b/path_creds.go
@@ -292,10 +292,9 @@ func (b *backend) createCreds(ctx context.Context, req *logical.Request, role *r
 	}
 
 	resp := b.Secret(kubeTokenType).Response(map[string]interface{}{
-		"service_account_namespace":       reqPayload.Namespace,
-		"service_account_name":            serviceAccountName,
-		"service_account_token":           token,
-		"service_account_token_audiences": reqPayload.Audiences,
+		"service_account_namespace": reqPayload.Namespace,
+		"service_account_name":      serviceAccountName,
+		"service_account_token":     token,
 	}, map[string]interface{}{
 		// the internal data is whatever we need to cleanup on revoke
 		// (service_account_name, role, role_binding).

--- a/path_creds.go
+++ b/path_creds.go
@@ -216,6 +216,11 @@ func (b *backend) createCreds(ctx context.Context, req *logical.Request, role *r
 		theTTL = b.System().MaxLeaseTTL()
 	}
 
+	theAudiences := role.TokenDefaultAudiences
+	if len(reqPayload.Audiences) != 0 {
+		theAudiences = reqPayload.Audiences
+	}
+
 	// These are created items to save internally and/or return to the caller
 	token := ""
 	serviceAccountName := ""
@@ -228,7 +233,7 @@ func (b *backend) createCreds(ctx context.Context, req *logical.Request, role *r
 	switch {
 	case role.ServiceAccountName != "":
 		// Create token for existing service account
-		status, err := client.createToken(ctx, reqPayload.Namespace, role.ServiceAccountName, theTTL, reqPayload.Audiences)
+		status, err := client.createToken(ctx, reqPayload.Namespace, role.ServiceAccountName, theTTL, theAudiences)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create a service account token for %s/%s: %s", reqPayload.Namespace, role.ServiceAccountName, err)
 		}
@@ -250,7 +255,7 @@ func (b *backend) createCreds(ctx context.Context, req *logical.Request, role *r
 			return nil, err
 		}
 
-		status, err := client.createToken(ctx, reqPayload.Namespace, genName, theTTL, reqPayload.Audiences)
+		status, err := client.createToken(ctx, reqPayload.Namespace, genName, theTTL, theAudiences)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create a service account token for %s/%s: %s", reqPayload.Namespace, genName, err)
 		}
@@ -277,7 +282,7 @@ func (b *backend) createCreds(ctx context.Context, req *logical.Request, role *r
 			return nil, err
 		}
 
-		status, err := client.createToken(ctx, reqPayload.Namespace, genName, theTTL, reqPayload.Audiences)
+		status, err := client.createToken(ctx, reqPayload.Namespace, genName, theTTL, theAudiences)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create a service account token for %s/%s: %s", reqPayload.Namespace, genName, err)
 		}

--- a/path_roles.go
+++ b/path_roles.go
@@ -22,18 +22,19 @@ const (
 )
 
 type roleEntry struct {
-	Name                 string            `json:"name" mapstructure:"name"`
-	K8sNamespaces        []string          `json:"allowed_kubernetes_namespaces" mapstructure:"allowed_kubernetes_namespaces"`
-	K8sNamespaceSelector string            `json:"allowed_kubernetes_namespace_selector" mapstructure:"allowed_kubernetes_namespace_selector"`
-	TokenMaxTTL          time.Duration     `json:"token_max_ttl" mapstructure:"token_max_ttl"`
-	TokenDefaultTTL      time.Duration     `json:"token_default_ttl" mapstructure:"token_default_ttl"`
-	ServiceAccountName   string            `json:"service_account_name" mapstructure:"service_account_name"`
-	K8sRoleName          string            `json:"kubernetes_role_name" mapstructure:"kubernetes_role_name"`
-	K8sRoleType          string            `json:"kubernetes_role_type" mapstructure:"kubernetes_role_type"`
-	RoleRules            string            `json:"generated_role_rules" mapstructure:"generated_role_rules"`
-	NameTemplate         string            `json:"name_template" mapstructure:"name_template"`
-	ExtraLabels          map[string]string `json:"extra_labels" mapstructure:"extra_labels"`
-	ExtraAnnotations     map[string]string `json:"extra_annotations" mapstructure:"extra_annotations"`
+	Name                  string            `json:"name" mapstructure:"name"`
+	K8sNamespaces         []string          `json:"allowed_kubernetes_namespaces" mapstructure:"allowed_kubernetes_namespaces"`
+	K8sNamespaceSelector  string            `json:"allowed_kubernetes_namespace_selector" mapstructure:"allowed_kubernetes_namespace_selector"`
+	TokenMaxTTL           time.Duration     `json:"token_max_ttl" mapstructure:"token_max_ttl"`
+	TokenDefaultTTL       time.Duration     `json:"token_default_ttl" mapstructure:"token_default_ttl"`
+	TokenDefaultAudiences []string          `json:"token_default_audiences" mapstructure:"token_default_audiences"`
+	ServiceAccountName    string            `json:"service_account_name" mapstructure:"service_account_name"`
+	K8sRoleName           string            `json:"kubernetes_role_name" mapstructure:"kubernetes_role_name"`
+	K8sRoleType           string            `json:"kubernetes_role_type" mapstructure:"kubernetes_role_type"`
+	RoleRules             string            `json:"generated_role_rules" mapstructure:"generated_role_rules"`
+	NameTemplate          string            `json:"name_template" mapstructure:"name_template"`
+	ExtraLabels           map[string]string `json:"extra_labels" mapstructure:"extra_labels"`
+	ExtraAnnotations      map[string]string `json:"extra_annotations" mapstructure:"extra_annotations"`
 }
 
 func (r *roleEntry) toResponseData() (map[string]interface{}, error) {
@@ -76,6 +77,11 @@ func (b *backend) pathRoles() []*framework.Path {
 				"token_default_ttl": {
 					Type:        framework.TypeDurationSecond,
 					Description: "The default ttl for generated Kubernetes service account tokens. If not set or set to 0, will use system default.",
+					Required:    false,
+				},
+				"token_default_audiences": {
+					Type:        framework.TypeCommaStringSlice,
+					Description: "The default audiences for generated Kubernetes service account tokens. If not set or set to \"\", will use k8s cluster setup.",
 					Required:    false,
 				},
 				"service_account_name": {
@@ -205,6 +211,9 @@ func (b *backend) pathRolesWrite(ctx context.Context, req *logical.Request, d *f
 	}
 	if tokenTTLRaw, ok := d.GetOk("token_default_ttl"); ok {
 		entry.TokenDefaultTTL = time.Duration(tokenTTLRaw.(int)) * time.Second
+	}
+	if tokenAudiencesRaw, ok := d.GetOk("token_default_audiences"); ok {
+		entry.TokenDefaultAudiences = strutil.RemoveDuplicates(tokenAudiencesRaw.([]string), true)
 	}
 	if svcAccount, ok := d.GetOk("service_account_name"); ok {
 		entry.ServiceAccountName = svcAccount.(string)

--- a/path_roles.go
+++ b/path_roles.go
@@ -81,7 +81,7 @@ func (b *backend) pathRoles() []*framework.Path {
 				},
 				"token_default_audiences": {
 					Type:        framework.TypeCommaStringSlice,
-					Description: "The default audiences for generated Kubernetes service account tokens. If not set or set to \"\", will use k8s cluster setup.",
+					Description: "The default audiences for generated Kubernetes service account tokens. If not set or set to \"\", will use k8s cluster default.",
 					Required:    false,
 				},
 				"service_account_name": {
@@ -213,7 +213,7 @@ func (b *backend) pathRolesWrite(ctx context.Context, req *logical.Request, d *f
 		entry.TokenDefaultTTL = time.Duration(tokenTTLRaw.(int)) * time.Second
 	}
 	if tokenAudiencesRaw, ok := d.GetOk("token_default_audiences"); ok {
-		entry.TokenDefaultAudiences = strutil.RemoveDuplicates(tokenAudiencesRaw.([]string), true)
+		entry.TokenDefaultAudiences = strutil.RemoveDuplicates(tokenAudiencesRaw.([]string), false)
 	}
 	if svcAccount, ok := d.GetOk("service_account_name"); ok {
 		entry.ServiceAccountName = svcAccount.(string)

--- a/path_roles_test.go
+++ b/path_roles_test.go
@@ -125,6 +125,7 @@ func TestRoles(t *testing.T) {
 			"allowed_kubernetes_namespace_selector": goodJSONSelector,
 			"kubernetes_role_name":                  "existing_role",
 			"token_default_ttl":                     "5h",
+			"token_default_audiences":               []string{"foobar"},
 		})
 		assert.NoError(t, err)
 		assert.NoError(t, resp.Error())
@@ -145,6 +146,7 @@ func TestRoles(t *testing.T) {
 			"service_account_name":                  "",
 			"token_max_ttl":                         time.Duration(0).Seconds(),
 			"token_default_ttl":                     time.Duration(time.Hour * 5).Seconds(),
+			"token_default_audiences":               []string{"foobar"},
 		}, resp.Data)
 
 		// Create one with yaml namespace selector and metadata
@@ -154,6 +156,7 @@ func TestRoles(t *testing.T) {
 			"extra_labels":                          testExtraLabels,
 			"kubernetes_role_name":                  "existing_role",
 			"kubernetes_role_type":                  "role",
+			"token_default_audiences":               []string{"foobar"},
 		})
 		assert.NoError(t, err)
 		assert.NoError(t, resp.Error())
@@ -173,6 +176,7 @@ func TestRoles(t *testing.T) {
 			"service_account_name":                  "",
 			"token_max_ttl":                         time.Duration(0).Seconds(),
 			"token_default_ttl":                     time.Duration(0).Seconds(),
+			"token_default_audiences":               []string{"foobar"},
 		}, resp.Data)
 
 		// Create one with json role rules
@@ -180,6 +184,7 @@ func TestRoles(t *testing.T) {
 			"allowed_kubernetes_namespaces": []string{"app1", "app2"},
 			"generated_role_rules":          goodJSONRules,
 			"token_default_ttl":             "5h",
+			"token_default_audiences":       []string{"foobar"},
 		})
 		assert.NoError(t, err)
 		assert.NoError(t, resp.Error())
@@ -199,6 +204,7 @@ func TestRoles(t *testing.T) {
 			"service_account_name":                  "",
 			"token_max_ttl":                         time.Duration(0).Seconds(),
 			"token_default_ttl":                     time.Duration(time.Hour * 5).Seconds(),
+			"token_default_audiences":               []string{"foobar"},
 		}, resp.Data)
 
 		// Create one with yaml role rules and metadata
@@ -208,6 +214,7 @@ func TestRoles(t *testing.T) {
 			"extra_labels":                  testExtraLabels,
 			"generated_role_rules":          goodYAMLRules,
 			"kubernetes_role_type":          "role",
+			"token_default_audiences":       []string{"foobar"},
 		})
 		assert.NoError(t, err)
 		assert.NoError(t, resp.Error())
@@ -227,6 +234,7 @@ func TestRoles(t *testing.T) {
 			"service_account_name":                  "",
 			"token_max_ttl":                         time.Duration(0).Seconds(),
 			"token_default_ttl":                     time.Duration(0).Seconds(),
+			"token_default_audiences":               []string{"foobar"},
 		}, resp.Data)
 
 		// update yamlrules (with a duplicate namespace)
@@ -250,6 +258,7 @@ func TestRoles(t *testing.T) {
 			"service_account_name":                  "",
 			"token_max_ttl":                         time.Duration(0).Seconds(),
 			"token_default_ttl":                     time.Duration(0).Seconds(),
+			"token_default_audiences":               []string{"foobar"},
 		}, resp.Data)
 
 		// Now there should be four roles returned from list


### PR DESCRIPTION
# Overview

This PR adds an option to set audiences for the k8s token created from the [TokenCreate API](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/#TokenRequestSpec)

# Design of Change
 - Add optional `token_default_audiences`  field to the roles path backend
- Add optional `audiences` field to the credentials path backend
 - Add `audiences` field to the credentials request payload
 - Add `audiences` param to `func (c *client) createToken(ctx context.Context, namespace string, name string, ttl time.Duration)`