### PR TITLE
fix typo in output of vault write kubernetes/creds/auto-managed-sa-and-role

### DIFF
--- a/path_creds.go
+++ b/path_creds.go
@@ -336,9 +336,9 @@ func (b *backend) createCreds(ctx context.Context, req *logical.Request, role *r
 	case err != nil:
 		return nil, fmt.Errorf("failed to read TTL of created Kubernetes token for %s/%s: %s", reqPayload.Namespace, genName, err)
 	case createdTokenTTL > theTTL:
-		respWarning = append(respWarning, fmt.Sprintf("the created Kubernetes service accout token TTL %v is greater than the Vault lease TTL %v", createdTokenTTL, theTTL))
+		respWarning = append(respWarning, fmt.Sprintf("the created Kubernetes service account token TTL %v is greater than the Vault lease TTL %v", createdTokenTTL, theTTL))
 	case createdTokenTTL < theTTL:
-		respWarning = append(respWarning, fmt.Sprintf("the created Kubernetes service accout token TTL %v is less than the Vault lease TTL %v; capping the lease TTL accordingly", createdTokenTTL, theTTL))
+		respWarning = append(respWarning, fmt.Sprintf("the created Kubernetes service account token TTL %v is less than the Vault lease TTL %v; capping the lease TTL accordingly", createdTokenTTL, theTTL))
 		resp.Secret.TTL = createdTokenTTL
 	}
 


### PR DESCRIPTION
# Overview

See subject line

# Design of Change

NA

# Related Issues/Pull Requests

NA

# Contributor Checklist

[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[x] Backwards compatible
