### PR TITLE
update go-jose.v2 to go-jose/v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Changes
 
+* Update `gopkg.in/square/go-jose.v2` to `github.com/go-jose/go-jose/v4`
 * Dependency updates
   * `github.com/docker/docker` v24.0.7+incompatible -> v24.0.9+incompatible
   * `github.com/go-jose/go-jose/v3` v3.0.1 -> v3.0.3

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.21.3
 
 require (
 	github.com/cenkalti/backoff/v3 v3.2.2
+	github.com/go-jose/go-jose/v4 v4.0.2
 	github.com/hashicorp/go-hclog v1.6.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-secure-stdlib/fileutil v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/frankban/quicktest v1.14.0 h1:+cqqvzZV87b4adx/5ayVOaYZ2CrvM4ejQvUdBzP
 github.com/frankban/quicktest v1.14.0/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=
 github.com/go-jose/go-jose/v3 v3.0.3 h1:fFKWeig/irsp7XD2zBxvnmA/XaRWp5V3CBsZXJF7G7k=
 github.com/go-jose/go-jose/v3 v3.0.3/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
+github.com/go-jose/go-jose/v4 v4.0.2 h1:R3l3kkBds16bO7ZFAEEcofK0MkrAJt3jlJznWZG0nvk=
+github.com/go-jose/go-jose/v4 v4.0.2/go.mod h1:WVf9LFMHh/QVrmqrOfqun0C45tMe3RoiKJMPvgWwLfY=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=


### PR DESCRIPTION
This is a short PR to update the go-jose library to v4 to avoid possible issues with v2 support, copying https://github.com/hashicorp/vault-plugin-auth-gcp/pull/203

It's possible v2.6.3 also fixes this issue (see https://github.com/go-jose/go-jose/releases/tag/v2.6.3), but this feels more future-proof (and the solution was readily available).
