### PR TITLE
[CHANGELOG] Prepare for v0.13.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.13.1
+### March 19, 2026
+
+* Automated dependency upgrades (#126)
+
 ## Unreleased
 
 * Tested with Kubernetes versions 1.35-1.31


### PR DESCRIPTION
Changelog update for version [v0.13.1](https://github.com/hashicorp/vault-plugin-secrets-kubernetes/releases/tag/v0.13.1).

---
_This PR was generated by an automated workflow._

Full log: https://github.com/hashicorp/vault-plugin-release/actions/runs/23320209600

