### PR TITLE
VAULT-48786: add metadata field to Kubernetes SE role

### DIFF
--- a/metadata_helpers.go
+++ b/metadata_helpers.go
@@ -1,0 +1,27 @@
+// Copyright IBM Corp. 2022, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package kubesecrets
+
+import "fmt"
+
+// toStringMap converts map[string]interface{} to map[string]string.
+// Returns an error if any value is not a string.
+func toStringMap(raw interface{}) (map[string]string, error) {
+	if raw == nil {
+		return make(map[string]string), nil
+	}
+	rawMap, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("expected map[string]interface{}, got %T", raw)
+	}
+	result := make(map[string]string, len(rawMap))
+	for k, v := range rawMap {
+		s, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("metadata value for key %q must be a string, got %T", k, v)
+		}
+		result[k] = s
+	}
+	return result, nil
+}

--- a/path_roles.go
+++ b/path_roles.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/custommetadata"
 	"github.com/hashicorp/vault/sdk/helper/template"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/mitchellh/mapstructure"
@@ -35,6 +36,7 @@ type roleEntry struct {
 	NameTemplate          string            `json:"name_template" mapstructure:"name_template"`
 	ExtraLabels           map[string]string `json:"extra_labels" mapstructure:"extra_labels"`
 	ExtraAnnotations      map[string]string `json:"extra_annotations" mapstructure:"extra_annotations"`
+	Metadata              map[string]string `json:"metadata" mapstructure:"metadata"`
 }
 
 // HasSingleK8sNamespace returns true if the role has a single namespace specified
@@ -52,6 +54,7 @@ func (r *roleEntry) toResponseData() (map[string]interface{}, error) {
 	// Format the TTLs as seconds
 	respData["token_default_ttl"] = r.TokenDefaultTTL.Seconds()
 	respData["token_max_ttl"] = r.TokenMaxTTL.Seconds()
+	respData["metadata"] = r.Metadata
 
 	return respData, nil
 }
@@ -129,6 +132,11 @@ func (b *backend) pathRoles() []*framework.Path {
 				"extra_annotations": {
 					Type:        framework.TypeKVPairs,
 					Description: "Additional annotations to apply to all generated Kubernetes objects.",
+					Required:    false,
+				},
+				"metadata": {
+					Type:        framework.TypeMap,
+					Description: "A map of string key-value pairs to associate with the role.",
 					Required:    false,
 				},
 			},
@@ -255,6 +263,19 @@ func (b *backend) pathRolesWrite(ctx context.Context, req *logical.Request, d *f
 	}
 	if extraAnnotations, ok := d.GetOk("extra_annotations"); ok {
 		entry.ExtraAnnotations = extraAnnotations.(map[string]string)
+	}
+	if rawMeta, ok := d.GetOk("metadata"); ok {
+		cm, err := toStringMap(rawMeta)
+		if err != nil {
+			return logical.ErrorResponse("error parsing metadata: %s", err.Error()), nil
+		}
+		if err := custommetadata.Validate(cm); err != nil {
+			return logical.ErrorResponse(err.Error()), nil
+		}
+		entry.Metadata = cm
+	}
+	if entry.Metadata == nil {
+		entry.Metadata = make(map[string]string)
 	}
 
 	// Validate the entry


### PR DESCRIPTION
## Summary

Adds a `metadata` field (`map[string]string`) to the Kubernetes secrets engine `roleEntry` struct, as part of the cross-engine custom metadata initiative (VAULT-48786).

## Changes

- `path_roles.go`: add `Metadata map[string]string` to `roleEntry` (no `omitempty`); register `metadata` as `TypeMap` optional field in `pathRoles()`; wire `toStringMap` + `custommetadata.Validate` in `pathRolesWrite` before `setRole`; expose `metadata` in `toResponseData()`
- `metadata_helpers.go`: package-local `toStringMap` helper (converts `map[string]interface{}` → `map[string]string`)

## Behaviour

- **Create/update with metadata present:** full-replace semantics (PUT). Validated against `sdk/helper/custommetadata` limits (64 keys, 128-char key, 512-char value).
- **Update with metadata absent:** unchanged (read-before-write in `pathRolesWrite` with `getRole`).
- **Validation failure:** returns `logical.ErrorResponse` before `storage.Put`.

## Test

```
vault secrets enable kubernetes
vault write kubernetes/roles/test \
  allowed_kubernetes_namespaces="default" \
  service_account_name="test-sa" \
  metadata="env=prod" "team=platform"
vault read kubernetes/roles/test
```